### PR TITLE
fix default mapping units

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
@@ -190,6 +190,9 @@ namespace ArcMapAddinCoordinateConversion
 
         public override void Project(int srfactoryCode)
         {
+            if (CoordinateConversionViewModel.AddInConfig.DisplayCoordinateType == CoordinateTypes.None)
+                return;
+
             ISpatialReference sr = null;
 
             Type t = Type.GetTypeFromProgID("esriGeometry.SpatialReferenceEnvironment");

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/CoordinateConversionButton.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/CoordinateConversionButton.cs
@@ -20,6 +20,7 @@ using ESRI.ArcGIS.Framework;
 using ESRI.ArcGIS.Carto;
 using ESRI.ArcGIS.Geometry;
 using ESRI.ArcGIS.Desktop.AddIns;
+using CoordinateConversionLibrary.ViewModels;
 
 namespace ArcMapAddinCoordinateConversion
 {
@@ -101,12 +102,20 @@ namespace ArcMapAddinCoordinateConversion
 
             var point = activeView.ScreenDisplay.DisplayTransformation.ToMapPoint(X, Y) as IPoint;
 
-            // always use WGS84
-            var sr = GetSR();
-
-            if (sr != null)
+            if (CoordinateConversionViewModel.AddInConfig.DisplayCoordinateType == CoordinateConversionLibrary.CoordinateTypes.None)
             {
-                point.Project(sr);
+                //IActiveView activeView = ArcMap.Document.FocusMap as IActiveView;
+                point.SpatialReference = ArcMap.Document.FocusMap.SpatialReference;
+            }
+            else
+            {
+                // always use WGS84
+                var sr = GetSR();
+
+                if (sr != null)
+                {
+                    point.Project(sr);
+                }
             }
 
             return point;

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDD.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDD.cs
@@ -87,6 +87,11 @@ namespace CoordinateConversionLibrary.Models
                         coord.Lat = Double.Parse(matchDD.Groups["latitude"].Value);
                         coord.Lon = Double.Parse(matchDD.Groups["longitude"].Value);
 
+                        if (coord.Lat > 90.0 || coord.Lat < -90.0)
+                            return false;
+                        if (coord.Lon > 180.0 || coord.Lon < -180.0)
+                            return false;
+
                         var temp = matchDD.Groups["latitudeSuffix"];
                         if (temp.Success && temp.Value.ToUpper().Equals("S"))
                         {

--- a/source/CoordinateConversion/ProAppCoordConversionModule/CoordinateConversionDockpaneViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/CoordinateConversionDockpaneViewModel.cs
@@ -31,6 +31,7 @@ using ArcGIS.Core.CIM;
 using System.Collections.ObjectModel;
 using ArcGIS.Desktop.Mapping.Events;
 using ArcGIS.Core.Data;
+using System.Text.RegularExpressions;
 
 namespace ProAppCoordConversionModule
 {
@@ -468,6 +469,27 @@ namespace ProAppCoordConversionModule
                 catch { }
             }
 
+            Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+
+            var matchMercator = regexMercator.Match(input);
+
+            if (matchMercator.Success && matchMercator.Length == input.Length)
+            {
+                try
+                {
+                    var Lat = Double.Parse(matchMercator.Groups["latitude"].Value);
+                    var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
+                    point = QueuedTask.Run(() =>
+                    {
+                        return MapPointBuilder.CreateMapPoint(Lon, Lat, MapView.Active.Map.SpatialReference);
+                    }).Result;
+                    return CoordinateType.DD;
+                }
+                catch (Exception ex)
+                {
+                    return CoordinateType.Unknown;
+                }
+            }
 
             return CoordinateType.Unknown;
         }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/CoordinateMapTool.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/CoordinateMapTool.cs
@@ -21,6 +21,7 @@ using ArcGIS.Desktop.Framework.Threading.Tasks;
 using ArcGIS.Desktop.Framework;
 using ProAppCoordConversionModule.UI;
 using CoordinateConversionLibrary.Helpers;
+using CoordinateConversionLibrary.ViewModels;
 
 namespace ProAppCoordConversionModule
 {
@@ -122,7 +123,9 @@ namespace ProAppCoordConversionModule
         {
             if (mp != null)
             {
-                mp = GeometryEngine.Project(mp, SpatialReferences.WGS84) as MapPoint;
+                if (CoordinateConversionViewModel.AddInConfig.DisplayCoordinateType != CoordinateConversionLibrary.CoordinateTypes.None)
+                    mp = GeometryEngine.Project(mp, SpatialReferences.WGS84) as MapPoint;
+
                 var vm = FrameworkApplication.DockPaneManager.Find("ProAppCoordConversionModule_CoordinateConversionDockpane") as CoordinateConversionDockpaneViewModel;
                 if (vm != null)
                 {
@@ -147,8 +150,10 @@ namespace ProAppCoordConversionModule
                     try
                     {
                         // for now we will always project to WGS84
-                        var result = GeometryEngine.Project(temp, SpatialReferences.WGS84);
-                        return result;
+                        if (CoordinateConversionViewModel.AddInConfig.DisplayCoordinateType != CoordinateConversionLibrary.CoordinateTypes.None)
+                            temp = GeometryEngine.Project(temp, SpatialReferences.WGS84) as MapPoint;
+                        
+                        return temp;
                     }
                     catch { }
                 }


### PR DESCRIPTION
For ArcMap and Pro fix the Default map units option for when the map units are in linear units like meters