### PR TITLE
Support Enable/Disable of Collect tab context menu items

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -42,10 +42,24 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             Mediator.Register(CoordinateConversionLibrary.Constants.SetListBoxItemAddInPoint, OnSetListBoxItemAddInPoint);
         }
 
+        public bool HasListBoxRightClickSelectedItem
+        {
+            get
+            {
+                return ListBoxItemAddInPoint != null;
+            }
+        }
+        public bool HasAnySelectedItems
+        {
+            get
+            {
+                return CoordinateAddInPoints.Any(p => p.IsSelected == true);
+            }
+        }
+
         public AddInPoint ListBoxItemAddInPoint { get; set; }
 
         public ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }
-
 
         private object _ListBoxSelectedItem = null;
         public object ListBoxSelectedItem
@@ -277,6 +291,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         private void OnSetListBoxItemAddInPoint(object obj)
         {
             ListBoxItemAddInPoint = obj as AddInPoint;
+            RaisePropertyChanged(() => HasListBoxRightClickSelectedItem);
         }
 
         private void ClearGraphicsContainer(IMap map)

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
@@ -83,11 +83,15 @@
                         <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
                             <MenuItem Command="{Binding DataContext.DeletePointCommand}"
                                       CommandParameter="{Binding Path=SelectedItems}"
-                                      Header="{x:Static prop:Resources.MenuLabelDelete}" />
-                            <MenuItem Command="{Binding DataContext.DeleteAllPointsCommand}" Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />
+                                      Header="{x:Static prop:Resources.MenuLabelDelete}"
+                                      IsEnabled="{Binding DataContext.HasAnySelectedItems}" />
+                            <MenuItem Command="{Binding DataContext.DeleteAllPointsCommand}"
+                                      Header="{x:Static prop:Resources.MenuLabelDeleteAll}"
+                                      IsEnabled="{Binding HasItems}" />
                             <MenuItem Command="{Binding DataContext.FlashPointCommand}"
                                       CommandParameter="{Binding}"
-                                      Header="{x:Static prop:Resources.HeaderFlash}" />
+                                      Header="{x:Static prop:Resources.HeaderFlash}"
+                                      IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}" />
                         </ContextMenu>
                     </ListBox.ContextMenu>
                     <ListBox.InputBindings>
@@ -98,6 +102,7 @@
                     </ListBox.InputBindings>
                     <ListBox.Style>
                         <Style TargetType="ListBox">
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="listBox_MouseRightButtonDown" />
                             <Setter Property="IsEnabled" Value="True" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsRunning}" Value="True">

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
@@ -33,5 +33,9 @@ namespace CoordinateConversionLibrary.Views
             Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.SetListBoxItemAddInPoint, obj);
             e.Handled = true;
         }
+        private void listBox_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.SetListBoxItemAddInPoint, null);
+        }
     }
 }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -41,6 +41,21 @@ namespace ProAppCoordConversionModule.ViewModels
             Mediator.Register(CoordinateConversionLibrary.Constants.SetListBoxItemAddInPoint, OnSetListBoxItemAddInPoint);
         }
 
+        public bool HasListBoxRightClickSelectedItem 
+        {
+            get 
+            {
+                return ListBoxItemAddInPoint != null;
+            }
+        }
+        public bool HasAnySelectedItems
+        {
+            get
+            {
+                return CoordinateAddInPoints.Any(p => p.IsSelected == true);
+            }
+        }
+
         public AddInPoint ListBoxItemAddInPoint { get; set; }
 
         public ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }
@@ -175,6 +190,7 @@ namespace ProAppCoordConversionModule.ViewModels
         private void OnSetListBoxItemAddInPoint(object obj)
         {
             ListBoxItemAddInPoint = obj as AddInPoint;
+            RaisePropertyChanged(() => HasListBoxRightClickSelectedItem);
         }
 
         #region overrides


### PR DESCRIPTION
Added support to Enable/Disable context menu items on the list box control on the Collect tab.

This will only allow the actions Delete/DeleteAll/Flash to be executed if they can run.