### PR TITLE
Flash property default needs to be false

### DIFF
--- a/source/CoordinateConversion/ProAppCoordConversionModule/UI/FlashEmbeddedControlViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/UI/FlashEmbeddedControlViewModel.cs
@@ -62,7 +62,7 @@ namespace ProAppCoordConversionModule.UI
             }
         }
         
-        private bool _flash = true;
+        private bool _flash = false;
         public bool Flash
         {
             get


### PR DESCRIPTION
Whoopsie, the default value of the Flash property should be false, not true.  It was causing the flash animation to run when you would use the map point tool.