### PR TITLE
create async method to set map tool as active tool

### DIFF
--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
@@ -173,9 +173,14 @@ namespace ProAppCoordConversionModule.ViewModels
 
         #endregion Mediator handlers
 
-        private void OnMapToolCommand(object obj)
+        private async Task SetAsCurrentToolAsync()
+        {	
+            await FrameworkApplication.SetCurrentToolAsync("ProAppCoordConversionModule_CoordinateMapTool");
+        }
+
+        private async void OnMapToolCommand(object obj)
         {
-            FrameworkApplication.SetCurrentToolAsync("ProAppCoordConversionModule_CoordinateMapTool");
+            await SetAsCurrentToolAsync();
         }
 
         internal async Task<string> AddGraphicToMap(Geometry geom, CIMColor color, bool IsTempGraphic = false, double size = 1.0, string text = "", SimpleMarkerStyle markerStyle = SimpleMarkerStyle.Circle, string tag = "")
@@ -244,7 +249,7 @@ namespace ProAppCoordConversionModule.ViewModels
 
             if (!IsToolActive)
             {
-                IsToolActive = true;
+                await SetAsCurrentToolAsync();
             }
 
             await QueuedTask.Run(() =>


### PR DESCRIPTION
Added this async method to set the map tool as the active tool so that we can properly await on it in the OnFlashPointCommandAsync method.  Without this sometimes the animation storyboard would begin before the map tool was activated and the animation would be "goofy".  Now things are in sync.