### PR TITLE
Fix for ArcMap crash in issue #290

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
@@ -232,10 +232,11 @@ namespace ArcMapAddinCoordinateConversion
 
         public string GetInputDisplayString()
         {
-            if (Point == null)
-                return "NA";
+            string result = "NA";
+            if (Point == null || Point.IsEmpty)
+                return result;
 
-            var result = string.Format("{0:0.0#####} {1:0.0#####}", Point.Y, Point.X);
+            result = string.Format("{0:0.0#####} {1:0.0#####}", Point.Y, Point.X);
 
             if (Point.SpatialReference == null)
                 return result;


### PR DESCRIPTION
Fix for ArcMap crash in issue #290

Discussed with @kgonzago and the fix is to display 'NA' in the input coordinates when the previous coordinate that was obtained from a mouse move on the map was from a location that a valid coordinate could not be obtained.

To test this fix, zoom out on the map so that a white border is displayed around the edges of the map.  At this extent, the edges have no valid coordinates.  Previously, if you'd then go to Edit Properties and switch the Display Coordinate, ArcMap would crash because it was trying to format a string using a Point that was invalid.

@kgonzago, please review and merge.