### PR TITLE
Addresses issue 351

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapCoordinateGet.cs
@@ -233,43 +233,50 @@ namespace ArcMapAddinCoordinateConversion
         public string GetInputDisplayString()
         {
             string result = "NA";
-            if (Point == null || Point.IsEmpty)
-                return result;
-
-            result = string.Format("{0:0.0#####} {1:0.0#####}", Point.Y, Point.X);
-
-            if (Point.SpatialReference == null)
-                return result;
-
-            var cn = Point as IConversionNotation;
-            if (cn != null)
+            try
             {
-                switch (CoordinateConversionLibraryConfig.AddInConfig.DisplayCoordinateType)
+                if (Point == null || Point.IsEmpty)
+                    return result;
+
+                result = string.Format("{0:0.0#####} {1:0.0#####}", Point.Y, Point.X);
+
+                if (Point.SpatialReference == null)
+                    return result;
+
+                var cn = Point as IConversionNotation;
+                if (cn != null)
                 {
-                    case CoordinateTypes.DD:
-                        result = cn.GetDDFromCoords(6);
-                        break;
-                    case CoordinateTypes.DDM:
-                        result = cn.GetDDMFromCoords(4);
-                        break;
-                    case CoordinateTypes.DMS:
-                        result = cn.GetDMSFromCoords(2);
-                        break;
-                    //case CoordinateTypes.GARS:
-                    //    result = cn.GetGARSFromCoords();
-                    //    break;
-                    case CoordinateTypes.MGRS:
-                        result = cn.CreateMGRS(5, true, esriMGRSModeEnum.esriMGRSMode_Automatic);
-                        break;
-                    case CoordinateTypes.USNG:
-                        result = cn.GetUSNGFromCoords(5, true, false);
-                        break;
-                    case CoordinateTypes.UTM:
-                        result = cn.GetUTMFromCoords(esriUTMConversionOptionsEnum.esriUTMAddSpaces);
-                        break;
-                    default:
-                        break;
+                    switch (CoordinateConversionLibraryConfig.AddInConfig.DisplayCoordinateType)
+                    {
+                        case CoordinateTypes.DD:
+                            result = cn.GetDDFromCoords(6);
+                            break;
+                        case CoordinateTypes.DDM:
+                            result = cn.GetDDMFromCoords(4);
+                            break;
+                        case CoordinateTypes.DMS:
+                            result = cn.GetDMSFromCoords(2);
+                            break;
+                        //case CoordinateTypes.GARS:
+                        //    result = cn.GetGARSFromCoords();
+                        //    break;
+                        case CoordinateTypes.MGRS:
+                            result = cn.CreateMGRS(5, true, esriMGRSModeEnum.esriMGRSMode_Automatic);
+                            break;
+                        case CoordinateTypes.USNG:
+                            result = cn.GetUSNGFromCoords(5, true, false);
+                            break;
+                        case CoordinateTypes.UTM:
+                            result = cn.GetUTMFromCoords(esriUTMConversionOptionsEnum.esriUTMAddSpaces);
+                            break;
+                        default:
+                            break;
+                    }
                 }
+            }
+            catch 
+            {
+                return "NA";
             }
             return result;
         }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AddInPoint.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AddInPoint.cs
@@ -44,7 +44,18 @@ namespace ArcMapAddinCoordinateConversion.Models
         }
         public string Text
         {
-            get { return pointConverter.Convert(point as object, typeof(string), null, null) as string; }
+            get 
+            {   
+                try
+                {
+                    return pointConverter.Convert(point as object, typeof(string), null, null) as string; 
+                }
+                catch
+                {
+                    return "NA";
+                }
+                
+            }
         }
 
         private string guid = string.Empty;

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
@@ -569,12 +569,9 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             }
 
             /*
-             * Commented out this section of code since it does not capture invalid coordinates
-             * like 00, 45, or 456987. 
-             * 
-             * TODO: update RegEx to accommodate for lack of delimeter
+             * Updated RegEx to capture invalid coordinates like 00, 45, or 456987. 
              */
-            Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]*(?<longitude>\-?\d+[.,]?\d*)");
+            Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]{1,}(?<longitude>\-?\d+[.,]?\d*)");
 
             var matchMercator = regexMercator.Match(input);
 

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
@@ -191,6 +191,8 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
         public override void ProcessInput(string input)
         {
+            if (input == "NA") return;
+
             base.ProcessInput(input);
 
             string result = string.Empty;
@@ -572,28 +574,28 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
              * 
              * TODO: update RegEx to accommodate for lack of delimeter
              */
-            //Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]*(?<longitude>\-?\d+[.,]?\d*)");
+            Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]*(?<longitude>\-?\d+[.,]?\d*)");
 
-            //var matchMercator = regexMercator.Match(input);
+            var matchMercator = regexMercator.Match(input);
 
-            //if (matchMercator.Success && matchMercator.Length == input.Length)
-            //{
-            //    try
-            //    {
-            //        var Lat = Double.Parse(matchMercator.Groups["latitude"].Value);
-            //        var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
-            //        IMap map = ((IMxDocument)ArcMap.Application.Document).FocusMap;
-            //        var sr = map.SpatialReference != null ? map.SpatialReference : ArcMapHelpers.GetSR((int)esriSRProjCS3Type.esriSRProjCS_WGS1984WebMercatorMajorAuxSphere);
-            //        point.X = Lon;
-            //        point.Y = Lat;
-            //        point.SpatialReference = sr;
-            //        return CoordinateType.DD;
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        // do nothing
-            //    }
-            //}
+            if (matchMercator.Success && matchMercator.Length == input.Length)
+            {
+                try
+                {
+                    var Lat = Double.Parse(matchMercator.Groups["latitude"].Value);
+                    var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
+                    IMap map = ((IMxDocument)ArcMap.Application.Document).FocusMap;
+                    var sr = map.SpatialReference != null ? map.SpatialReference : ArcMapHelpers.GetSR((int)esriSRProjCS3Type.esriSRProjCS_WGS1984WebMercatorMajorAuxSphere);
+                    point.X = Lon;
+                    point.Y = Lat;
+                    point.SpatialReference = sr;
+                    return CoordinateType.DD;
+                }
+                catch (Exception ex)
+                {
+                    // do nothing
+                }
+            }
 
             return CoordinateType.Unknown;
         }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -353,10 +353,10 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                 sfDlg = new SaveFileDialog();
                 sfDlg.AddExtension = true;
                 sfDlg.CheckPathExists = true;
-                sfDlg.DefaultExt = ext; // "kmz";
-                sfDlg.Filter = filter; // "KMZ File (*.kmz)|*.kmz";
+                sfDlg.DefaultExt = ext; 
+                sfDlg.Filter = filter;
                 sfDlg.OverwritePrompt = true;
-                sfDlg.Title = title; // "Choose location to create KMZ file";
+                sfDlg.Title = title;
 
             }
             sfDlg.FileName = "";
@@ -470,12 +470,15 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
         private void AddCollectionPoint(IPoint point)
         {
-            var color = new RgbColorClass() { Red = 255 } as IColor;
-            var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
-            var addInPoint = new AddInPoint() { Point = point, GUID = guid };
-            CoordinateAddInPoints.Add(addInPoint);
+            if (!point.IsEmpty)
+            {
+                var color = new RgbColorClass() { Red = 255 } as IColor;
+                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
+                var addInPoint = new AddInPoint() { Point = point, GUID = guid };
+                CoordinateAddInPoints.Add(addInPoint);
 
-            GraphicsList.Add(new AMGraphic(guid, point, true));
+                GraphicsList.Add(new AMGraphic(guid, point, true));
+            }
         }
 
         private void RemoveGraphics(List<string> guidList)

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Models/AddInPoint.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Models/AddInPoint.cs
@@ -47,7 +47,17 @@ namespace ProAppCoordConversionModule.Models
         }
         public string Text
         {
-            get { return MapPointHelper.GetMapPointAsDisplayString(Point); }
+            get 
+            {
+                try
+                {
+                    return MapPointHelper.GetMapPointAsDisplayString(Point); 
+                }
+                catch
+                {
+                    return "NA";
+                }
+            }
         }
 
         private string guid = string.Empty;

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ProCoordinateGet.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ProCoordinateGet.cs
@@ -250,7 +250,7 @@ namespace ProAppCoordConversionModule
             }
             catch(Exception ex)
             {
-                // do nothing
+                return "NA";
             }
             return result;
         }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
@@ -560,33 +560,30 @@ namespace ProAppCoordConversionModule.ViewModels
             }
 
             /*
-             * Commented out this section of code since it does not capture invalid coordinates
-             * like 00, 45, or 456987. 
-             * 
-             * TODO: update RegEx to accommodate for lack of delimeter
+             * Updated RegEx to capture invalid coordinates like 00, 45, or 456987. 
              */
-            //Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]*(?<longitude>\-?\d+[.,]?\d*)");
+            Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+[.,]?\d*)[+,;:\s]{1,}(?<longitude>\-?\d+[.,]?\d*)");
 
-            //var matchMercator = regexMercator.Match(input);
+            var matchMercator = regexMercator.Match(input);
 
-            //if (matchMercator.Success && matchMercator.Length == input.Length)
-            //{
-            //    try
-            //    {
-            //        var Lat = Double.Parse(matchMercator.Groups["latitude"].Value);
-            //        var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
-            //        var sr = proCoordGetter.Point != null ? proCoordGetter.Point.SpatialReference : SpatialReferences.WebMercator;
-            //        point = await QueuedTask.Run(() =>
-            //        {
-            //            return MapPointBuilder.CreateMapPoint(Lon, Lat, sr);
-            //        });//.Result;
-            //        return new CCCoordinate() { Type = CoordinateType.DD, Point = point };
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        return new CCCoordinate() { Type = CoordinateType.Unknown, Point = null };
-            //    }
-            //}
+            if (matchMercator.Success && matchMercator.Length == input.Length)
+            {
+                try
+                {
+                    var Lat = Double.Parse(matchMercator.Groups["latitude"].Value);
+                    var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
+                    var sr = proCoordGetter.Point != null ? proCoordGetter.Point.SpatialReference : SpatialReferences.WebMercator;
+                    point = await QueuedTask.Run(() =>
+                    {
+                        return MapPointBuilder.CreateMapPoint(Lon, Lat, sr);
+                    });//.Result;
+                    return new CCCoordinate() { Type = CoordinateType.DD, Point = point };
+                }
+                catch (Exception ex)
+                {
+                    return new CCCoordinate() { Type = CoordinateType.Unknown, Point = null };
+                }
+            }
 
             return new CCCoordinate() { Type = CoordinateType.Unknown, Point = null };
         }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
@@ -136,6 +136,8 @@ namespace ProAppCoordConversionModule.ViewModels
 
         public override void ProcessInput(string input)
         {
+            if (input == "NA") return;
+
             string result = string.Empty;
             //MapPoint point;
             HasInputError = false;


### PR DESCRIPTION
When a user creates a coordinate that is out of bounds, the batch conversion captures that as an empty item in the list. Code is updated to handle that and now outputs empty items as "NA".

@csmoore Can you review and merge? Thanks.