### PR TITLE
V3025

### DIFF
--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
@@ -185,8 +185,8 @@ namespace CoordinateConversionLibrary.Models
             {
                 case "":
                 case "DDM":
-                    sb.AppendFormat(fi, "{0}° {1:0.0#####}\' {3}", Math.Abs(this.LatDegrees), this.LatMinutes, this.LatDegrees < 0 ? "S" : "N");
-                    sb.AppendFormat(fi, " {0}° {1:0.0#####}\' {3}", Math.Abs(this.LonDegrees), this.LonMinutes, this.LonDegrees < 0 ? "W" : "E");
+                    sb.AppendFormat(fi, "{0}° {1:0.0#####}\' {2}", Math.Abs(this.LatDegrees), this.LatMinutes, this.LatDegrees < 0 ? "S" : "N");
+                    sb.AppendFormat(fi, " {0}° {1:0.0#####}\' {2}", Math.Abs(this.LonDegrees), this.LonMinutes, this.LonDegrees < 0 ? "W" : "E");
                     break;
                 default:
                     throw new Exception("CoordinateDDM.ToString(): Invalid formatting string.");


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'AppendFormat' function. Format items not used: {3}. Arguments not used: 4th. CoordinateConversionLibrary CoordinateDDM.cs 188

- Incorrect format. A different number of format items is expected while calling 'AppendFormat' function. Format items not used: {3}. Arguments not used: 4th. CoordinateConversionLibrary CoordinateDDM.cs 189