### PR TITLE
Fix static analysis issues

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/FeatureClassUtils.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/FeatureClassUtils.cs
@@ -104,11 +104,8 @@ namespace ArcMapAddinCoordinateConversion.Models
                             return null;
                         }
 
-                        if (ipSelectedObject != null && ipSelectedObject is IGxDataset)
-                        {
-                            ipGxDataset = (IGxDataset)ipSelectedObject;
-                            ipDataset = ipGxDataset.Dataset;
-                        }
+                        ipGxDataset = (IGxDataset)ipSelectedObject;
+                        ipDataset = ipGxDataset.Dataset;
                     }
 
                     return m_ipSaveAsGxDialog.FinalLocation.FullName + "\\" + m_ipSaveAsGxDialog.Name;
@@ -333,7 +330,6 @@ namespace ArcMapAddinCoordinateConversion.Models
             IFieldsEdit pFldsEdt = new FieldsClass();
             IFieldEdit pFldEdt = new FieldClass();
 
-            pFldEdt = new FieldClass();
             pFldEdt.Type_2 = esriFieldType.esriFieldTypeOID;
             pFldEdt.Name_2 = "OBJECTID";
             pFldEdt.AliasName_2 = "OBJECTID";

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
@@ -111,12 +111,9 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                 simpleMarkerSymbol.Size = 15;
                 simpleMarkerSymbol.Style = esriSimpleMarkerStyle.esriSMSDiamond;
 
-                IElement element = null;
-
                 IMarkerElement markerElement = new MarkerElementClass();
 
                 markerElement.Symbol = simpleMarkerSymbol;
-                element = markerElement as IElement;
 
                 IPolygon poly = null;
                 if (InputCoordinateType == CoordinateType.MGRS || InputCoordinateType == CoordinateType.USNG)

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -131,9 +131,6 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             var items = obj as IList;
             var objects = items.Cast<AddInPoint>().ToList();
 
-            if (objects == null)
-                return;
-
             DeletePoints(objects);
         }
 
@@ -176,10 +173,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             var items = obj as IList;
             var objects = items.Cast<AddInPoint>().ToList();
 
-            if (objects == null)
-                return;            
-
-            if (objects == null || !objects.Any())
+            if (!objects.Any())
                 return;
 
             var sb = new StringBuilder();
@@ -255,7 +249,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
                         var aiPoints = CoordinateAddInPoints.ToList();
 
-                        if (aiPoints == null || !aiPoints.Any())
+                        if (!aiPoints.Any())
                             return;
 
                         var csvExport = new CsvExport();
@@ -313,8 +307,6 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             IGeoFeatureLayer geoLayer = outputFeatureLayer as IGeoFeatureLayer;
             if(geoLayer.FeatureClass.ShapeType == esriGeometryType.esriGeometryPoint)
             {
-                IFeatureRenderer pFeatureRender;
-                pFeatureRender = (IFeatureRenderer)new SimpleRenderer();
                 ISimpleMarkerSymbol pSimpleMarkerSymbol = new SimpleMarkerSymbolClass();
                 pSimpleMarkerSymbol.Style = esriSimpleMarkerStyle.esriSMSCircle;
                 pSimpleMarkerSymbol.Size = 3.0;
@@ -327,8 +319,6 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             }
             else if (geoLayer.FeatureClass.ShapeType != esriGeometryType.esriGeometryPolyline)
             {
-                IFeatureRenderer pFeatureRender;
-                pFeatureRender = (IFeatureRenderer)new SimpleRenderer();
                 ISimpleFillSymbol pSimpleFillSymbol = new SimpleFillSymbolClass();
                 pSimpleFillSymbol.Style = esriSimpleFillStyle.esriSFSHollow;
                 pSimpleFillSymbol.Outline.Width = 0.4;
@@ -471,7 +461,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
         private void AddCollectionPoint(IPoint point)
         {
-            if (!point.IsEmpty && point != null)
+            if (point != null && !point.IsEmpty)
             {
                 var color = new RgbColorClass() { Red = 255 } as IColor;
                 var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ExportCSV.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ExportCSV.cs
@@ -132,7 +132,7 @@ namespace Jitbit.Utils
             if (value is INullable && ((INullable)value).IsNull) return "";
             if (value is DateTime)
             {
-                if (((DateTime)value).TimeOfDay.TotalSeconds == 0)
+                if ((int)((DateTime)value).TimeOfDay.TotalSeconds == 0)
                     return ((DateTime)value).ToString("yyyy-MM-dd");
                 return ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss");
             }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ImportCSV.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ImportCSV.cs
@@ -74,7 +74,6 @@ namespace CoordinateConversionLibrary.Helpers
         public static IEnumerable<T> Import<T>(Stream stream, string[] fieldNames) where T : new()
         {
             List<T> list = new List<T>();
-            char sep = '\0';
             using (StreamReader reader = new StreamReader(stream))
             {
                 string line = reader.ReadLine();
@@ -83,7 +82,7 @@ namespace CoordinateConversionLibrary.Helpers
                 if (string.IsNullOrEmpty(line))
                     return list;
 
-                var charSep = sep != '\0' ? sep : GetSeparator(line);
+                var charSep = GetSeparator(line);
 
                 string[] row = line.Split(charSep);
                 List<ImportDescriptor> headers = ParseHeader<T>(row, fieldNames);

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/NotificationObject.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/NotificationObject.cs
@@ -34,8 +34,7 @@ namespace CoordinateConversionLibrary.Helpers
 
         private void RaisePropertyChanged(string propertyName)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDD.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDD.cs
@@ -294,7 +294,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
@@ -285,7 +285,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDMS.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDMS.cs
@@ -332,7 +332,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateGARS.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateGARS.cs
@@ -202,7 +202,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateMGRS.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateMGRS.cs
@@ -217,7 +217,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateUTM.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateUTM.cs
@@ -215,7 +215,6 @@ namespace CoordinateConversionLibrary.Models
                     if (endIndexNeeded)
                     {
                         sb.Append("}");
-                        endIndexNeeded = false;
                     }
 
                     return String.Format(sb.ToString(), olist.ToArray());

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/EditOutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/EditOutputCoordinateViewModel.cs
@@ -37,16 +37,6 @@ namespace CoordinateConversionLibrary.ViewModels
                                                                     Properties.Resources.CategoryListUSNG,
                                                                     Properties.Resources.CategoryListUTM };
             }
-            else
-            {
-                CategoryList = new ObservableCollection<string>() { Properties.Resources.CategoryListDD,
-                                                                    Properties.Resources.CategoryListDDM,
-                                                                    Properties.Resources.CategoryListDMS,
-                                                                    //Properties.Resources.CategoryListGARS,
-                                                                    Properties.Resources.CategoryListMGRS,
-                                                                    Properties.Resources.CategoryListUSNG,
-                                                                    Properties.Resources.CategoryListUTM };
-            }
             FormatList = new ObservableCollection<string>() { "One",
                                                               "Two",
                                                               "Three",

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -143,9 +143,6 @@ namespace ProAppCoordConversionModule.ViewModels
             var items = obj as IList;
             var objects = items.Cast<AddInPoint>().ToList();
 
-            if (objects == null)
-                return;
-
             DeletePoints(objects);
         }
 
@@ -179,10 +176,7 @@ namespace ProAppCoordConversionModule.ViewModels
             var items = obj as IList;
             var objects = items.Cast<AddInPoint>().ToList();
 
-            if (objects == null)
-                return;
-
-            if (objects == null || !objects.Any())
+            if (!objects.Any())
                 return;
 
             var sb = new StringBuilder();
@@ -232,7 +226,7 @@ namespace ProAppCoordConversionModule.ViewModels
                         {
                             var aiPoints = CoordinateAddInPoints.ToList();
 
-                            if (aiPoints == null || !aiPoints.Any())
+                            if (!aiPoints.Any())
                                 return;
 
                             var csvExport = new CsvExport();


### PR DESCRIPTION
[V3022](https://www.viva64.com/en/w/V3022) Expression 'objects == null' is always false. CollectTabViewModel.cs 134
[V3022](https://www.viva64.com/en/w/V3022) Expression 'objects == null' is always false. CollectTabViewModel.cs 179
[V3022](https://www.viva64.com/en/w/V3022) Expression 'objects == null' is always false. ProCollectTabViewModel.cs 146
[V3022](https://www.viva64.com/en/w/V3022) Expression 'objects == null' is always false. ProCollectTabViewModel.cs 182
[V3027](https://www.viva64.com/en/w/V3027) The variable 'point' was utilized in the logical expression before it was verified against null in the same logical expression. CollectTabViewModel.cs 474
[V3004](https://www.viva64.com/en/w/V3004) The 'then' statement is equivalent to the 'else' statement. EditOutputCoordinateViewModel.cs 30
[V3063](https://www.viva64.com/en/w/V3063) A part of conditional expression is always true if it is evaluated: ipSelectedObject != null. FeatureClassUtils.cs 107
[V3083](https://www.viva64.com/en/w/V3083) Unsafe invocation of event 'PropertyChanged', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. NotificationObject.cs 38
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateMGRS.cs 220
[V3063](https://www.viva64.com/en/w/V3063) A part of conditional expression is always false if it is evaluated: aiPoints == null. CollectTabViewModel.cs 252
[V3137](https://www.viva64.com/en/w/V3137) The 'pFeatureRender' variable is assigned but is not used until the end of the function. CollectTabViewModel.cs 311
[V3137](https://www.viva64.com/en/w/V3137) The 'pFeatureRender' variable is assigned but is not used until the end of the function. CollectTabViewModel.cs 325
[V3137](https://www.viva64.com/en/w/V3137) The 'element' variable is assigned but is not used until the end of the function. ArcMapTabBaseViewModel.cs 119
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateGARS.cs 205
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateUTM.cs 218
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateDD.cs 297
[V3063](https://www.viva64.com/en/w/V3063) A part of conditional expression is always false if it is evaluated: aiPoints == null. ProCollectTabViewModel.cs 229
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateDDM.cs 288
[V3137](https://www.viva64.com/en/w/V3137) The 'endIndexNeeded' variable is assigned but is not used until the end of the function. CoordinateDMS.cs 335
[V3008](https://www.viva64.com/en/w/V3008) The 'pFldEdt' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 336, 334. FeatureClassUtils.cs 336
[V3024](https://www.viva64.com/en/w/V3024) An odd precise comparison. Consider using a comparison with defined precision: Math.Abs(A - B) < Epsilon. ExportCSV.cs 135
[V3022](https://www.viva64.com/en/w/V3022) Expression 'sep != '\0'' is always false. ImportCSV.cs 86

Analysed using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) as a part of [pinguem.ru](https://pinguem.ru) competition