### PR TITLE
Fixed issue with "Default Map Unit"

### DIFF
--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ConversionUtils.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/ConversionUtils.cs
@@ -26,7 +26,7 @@ namespace CoordinateConversionLibrary.Helpers
     {
         public static CoordinateType GetCoordinateString(string input, out string formattedString)
         {
-            formattedString = string.Empty;
+            formattedString = input;
             // DD
             CoordinateDD dd;
             if (CoordinateDD.TryParse(input, out dd) == true)


### PR DESCRIPTION
Coordinates displayed using `Default Map Unit` notation were not showing up. Added a quick fix to handle that type of notation. This affects D&D issues:
[#218](https://github.com/Esri/distance-direction-addin-dotnet/issues/218)
[#220](https://github.com/Esri/distance-direction-addin-dotnet/issues/220)
[#222](https://github.com/Esri/distance-direction-addin-dotnet/issues/222)

@csmoore Please review when you're free. Thanks.