### PR TITLE
Delivery for Coordinate Conversion Addin DotNet V2 – UAT fixes

### DIFF
--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/EditOutputCoordinateView.xaml.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/EditOutputCoordinateView.xaml.cs
@@ -19,6 +19,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using CoordinateConversionLibrary.Models;
 using CoordinateConversionLibrary.ViewModels;
+using System.Text.RegularExpressions;
 
 namespace CoordinateConversionLibrary.Views
 {
@@ -59,21 +60,42 @@ namespace CoordinateConversionLibrary.Views
         {
             var vm = this.DataContext as EditOutputCoordinateViewModel;
 
+            Regex alphanumericRegex = new Regex("^[a-zA-Z0-9]*$");
+            Regex nonNumericStartRegex = new Regex("^(?![0-9])");
+            Regex characterLimitRegex = new Regex("^[a-zA-Z0-9]{0,10}?$");
+
             if (vm == null)
                 return;
 
-            if(vm.Names.Contains(vm.OutputCoordItem.Name))
+            if (vm.Names.Contains(vm.OutputCoordItem.Name))
             {
                 // no duplicates please
                 e.Handled = false;
                 MessageBox.Show(string.Format("The name '{0}' is already used.", vm.OutputCoordItem.Name));
                 return;
             }
-
-            if(string.IsNullOrWhiteSpace(vm.OutputCoordItem.Name))
+            else if (string.IsNullOrWhiteSpace(vm.OutputCoordItem.Name))
             {
                 e.Handled = false;
                 MessageBox.Show("Name is required.");
+                return;
+            }
+            else if (!alphanumericRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name should only contain alphabet and numbers.");
+                return;
+            }
+            else if (!nonNumericStartRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name should not start with a number.");
+                return;
+            }
+            else if (!characterLimitRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name must be 10 characters or less.");
                 return;
             }
 

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProEditOutputCoordinateView.xaml.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProEditOutputCoordinateView.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using CoordinateConversionLibrary.Models;
 using CoordinateConversionLibrary.ViewModels;
+using System.Text.RegularExpressions;
 
 namespace CoordinateConversionLibrary.Views
 {
@@ -43,6 +44,10 @@ namespace CoordinateConversionLibrary.Views
         {
             var vm = this.DataContext as EditOutputCoordinateViewModel;
 
+            Regex alphanumericRegex = new Regex("^[a-zA-Z0-9]*$");
+            Regex nonNumericStartRegex = new Regex("^(?![0-9])");
+            Regex characterLimitRegex = new Regex("^[a-zA-Z0-9]{0,10}?$");
+
             if (vm == null)
                 return;
 
@@ -53,11 +58,28 @@ namespace CoordinateConversionLibrary.Views
                 MessageBox.Show(string.Format("The name '{0}' is already used.", vm.OutputCoordItem.Name));
                 return;
             }
-
-            if (string.IsNullOrWhiteSpace(vm.OutputCoordItem.Name))
+            else if (string.IsNullOrWhiteSpace(vm.OutputCoordItem.Name))
             {
                 e.Handled = false;
                 MessageBox.Show("Name is required.");
+                return;
+            }
+            else if (!alphanumericRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name should only contain alphabet and numbers.");
+                return;
+            }
+            else if (!nonNumericStartRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name should not start with a number.");
+                return;
+            }
+            else if (!characterLimitRegex.IsMatch(vm.OutputCoordItem.Name))
+            {
+                e.Handled = false;
+                MessageBox.Show("The name must be 10 characters or less.");
                 return;
             }
 


### PR DESCRIPTION
This build addresses the UAT feedback provided pull request #497. 
The validations implemented are:
- Not allow more than 10 characters
- Only allow alphanumeric characters
- Not allow name to be started with a number

The impacting Github ticktes are mentioned below:
#493 - Export all coordinate types from the output section to Shapefile
#495 - Export all coordinate types from the output section to KMZ
