### PR TITLE
Address Additional Addin warnings

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapAddinCoordinateConversion.csproj
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapAddinCoordinateConversion.csproj
@@ -53,7 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -64,6 +64,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ESRI.ArcGIS.ADF.Connection.Local, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=x86">

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Config.esriaddinx
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Config.esriaddinx
@@ -10,7 +10,7 @@
   <Targets>
     <Target name="Desktop" version="10.3" />
   </Targets>
-  <AddIn language="CLR" library="CoordinateConversion.dll" namespace="ArcMapAddinCoordinateConversion">
+  <AddIn language="CLR4.5" library="CoordinateConversion.dll" namespace="ArcMapAddinCoordinateConversion">
     <ArcMap>
       <Commands>
         <Button id="Esri_ArcMapAddinCoordinateConversion_ContextCopyDD" class="ContextCopyDD" message="Add-in command to copy map point to clipboard." caption="Copy DD Coordinate" tip="Copy DD to clipboard" category="Add-In Controls" image="Images\coordinate-conversion-16.png" />

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Config.esriaddinx
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Config.esriaddinx
@@ -10,7 +10,7 @@
   <Targets>
     <Target name="Desktop" version="10.3" />
   </Targets>
-  <AddIn language="CLR4.5" library="CoordinateConversion.dll" namespace="ArcMapAddinCoordinateConversion">
+  <AddIn language="CLR" library="CoordinateConversion.dll" namespace="ArcMapAddinCoordinateConversion">
     <ArcMap>
       <Commands>
         <Button id="Esri_ArcMapAddinCoordinateConversion_ContextCopyDD" class="ContextCopyDD" message="Add-in command to copy map point to clipboard." caption="Copy DD Coordinate" tip="Copy DD to clipboard" category="Add-In Controls" image="Images\coordinate-conversion-16.png" />


### PR DESCRIPTION
Address a few additional warnings noted in: https://github.com/Esri/coordinate-conversion-addin-dotnet/issues/436#issuecomment-405394370 : 


```
coordinate-conversion-addin-dotnet\source\CoordinateConversion\ArcMapAddinCoordinateConversion\Config.esriaddinx : warning : The 'language' attribute in the AddIn element is invalid - The value 'CLR4.5'  is invalid according to the project's target framework version - The value should be 'CLR'.
Microsoft.Common.CurrentVersion.targets(1820,5): warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "ESRI.ArcGIS.ADF.Connection.Local, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=x86", "x86". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.
```

FYI @ACueva @kgonzago 