### PR TITLE
#533 - Enlarge halo so selected point more visible

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Helpers/ArcMapHelpers.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Helpers/ArcMapHelpers.cs
@@ -83,12 +83,23 @@ namespace ArcMapAddinCoordinateConversion.Helpers
 
             return null;
         }
+
+        public static double DefaultMarkerSize
+        {
+            get { return 7.0;  }
+        }
+
+        public static double DefaultOutlineSize
+        {
+            get { return 1.7; }
+        }
+        
         /// <summary>
         /// Adds a graphic element to the map graphics container
         /// Returns GUID
         /// </summary>
         /// <param name="geom">IGeometry</param>
-        public static string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false, esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, int size = 5)
+        public static string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false, esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, double size = 5)
         {
             if ((geom == null) || (ArcMap.Document == null) || (ArcMap.Document.FocusMap == null) 
                 || (ArcMap.Document.FocusMap.SpatialReference == null))

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -462,14 +462,15 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                                 var simpleMarkerSymbol = (ISimpleMarkerSymbol)new SimpleMarkerSymbol();
 
                                 simpleMarkerSymbol.Color = sms.Color;
-                                simpleMarkerSymbol.Size = sms.Size;
+                                simpleMarkerSymbol.Size = ArcMapHelpers.DefaultMarkerSize;
                                 simpleMarkerSymbol.Style = sms.Style;
-                                simpleMarkerSymbol.OutlineSize = 1;
+                                simpleMarkerSymbol.OutlineSize = 1.7;
 
                                 if (aiPoint.IsSelected)
                                 {
                                     var color = (IColor)new RgbColorClass() { Green = 255 };
                                     // Marker symbols
+                                    simpleMarkerSymbol.Size = ArcMapHelpers.DefaultMarkerSize + ArcMapHelpers.DefaultOutlineSize;
                                     simpleMarkerSymbol.Outline = true;
                                     simpleMarkerSymbol.OutlineColor = color;
                                     doUpdate = true;
@@ -503,7 +504,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             if (point != null && !point.IsEmpty)
             {
                 var color = (IColor)new RgbColorClass() { Red = 255 };
-                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
+                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, ArcMapHelpers.DefaultMarkerSize);
                 var addInPoint = new AddInPoint() { Point = point, GUID = guid };
 
                 //Add point to the top of the list

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
@@ -223,7 +223,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             if (point != null && !point.IsEmpty)
             {
                 var color = new RgbColorClass() { Red = 255 } as IColor;
-                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
+                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, ArcMapHelpers.DefaultMarkerSize);
                 var addInPoint = new AddInPoint() { Point = point, GUID = guid };
 
                 //Add point to the top of the list


### PR DESCRIPTION
See #533 - Halo and selected symbol too small in ArcMap.

Should look like this now:

![image](https://user-images.githubusercontent.com/3090809/52348378-2751af80-29f2-11e9-8a21-b678ff46b40a.png)
