### PR TITLE
Coordinate Conversion Addin DotNet 2.3 Release 

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapAddinCoordinateConversion.csproj
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ArcMapAddinCoordinateConversion.csproj
@@ -116,6 +116,7 @@
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
+    <Reference Include="ESRI.ArcGIS.Geoprocessor, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL" />
     <Reference Include="ESRI.ArcGIS.System">
       <Private>False</Private>
     </Reference>

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/DockableWindowCoordinateConversion.xaml
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/DockableWindowCoordinateConversion.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:libprop="clr-namespace:CoordinateConversionLibrary.Properties;assembly=CoordinateConversionLibrary"
              xmlns:viewModels="clr-namespace:ArcMapAddinCoordinateConversion.ViewModels"
+             ScrollViewer.VerticalScrollBarVisibility="Hidden"
              Width="300"
              Height="300">
     <UserControl.Resources>
@@ -11,9 +12,7 @@
     <UserControl.DataContext>
         <StaticResourceExtension ResourceKey="viewModelMain" />
     </UserControl.DataContext>
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Grid ScrollViewer.CanContentScroll="True">
-            <UserControl Content="{Binding ConvertTabView}" />
-        </Grid>
-    </ScrollViewer>
+    <Grid ScrollViewer.VerticalScrollBarVisibility="Hidden">
+        <UserControl Content="{Binding ConvertTabView}" />
+    </Grid>
 </UserControl>

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Helpers/ArcMapHelpers.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Helpers/ArcMapHelpers.cs
@@ -17,6 +17,9 @@ using ESRI.ArcGIS.ArcMapUI;
 using ESRI.ArcGIS.Carto;
 using ESRI.ArcGIS.Display;
 using ESRI.ArcGIS.Geometry;
+using ESRI.ArcGIS.Geodatabase;
+using ESRI.ArcGIS.DataSourcesGDB;
+using System.Collections.Generic;
 
 namespace ArcMapAddinCoordinateConversion.Helpers
 {
@@ -83,12 +86,23 @@ namespace ArcMapAddinCoordinateConversion.Helpers
 
             return null;
         }
+
+        public static double DefaultMarkerSize
+        {
+            get { return 7.0;  }
+        }
+
+        public static double DefaultOutlineSize
+        {
+            get { return 1.7; }
+        }
+        
         /// <summary>
         /// Adds a graphic element to the map graphics container
         /// Returns GUID
         /// </summary>
         /// <param name="geom">IGeometry</param>
-        public static string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false, esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, int size = 5)
+        public static string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false, esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, double size = 5)
         {
             if ((geom == null) || (ArcMap.Document == null) || (ArcMap.Document.FocusMap == null) 
                 || (ArcMap.Document.FocusMap.SpatialReference == null))
@@ -350,6 +364,5 @@ namespace ArcMapAddinCoordinateConversion.Helpers
                 System.Diagnostics.Debug.WriteLine(ex.Message);
             }
         }
-
     }
 }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AMGraphic.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AMGraphic.cs
@@ -13,16 +13,19 @@
 // limitations under the License.
 
 using ESRI.ArcGIS.Geometry;
+using System;
+using System.Collections.Generic;
 
 namespace ArcMapAddinCoordinateConversion.Models
 {
     public class AMGraphic
     {
-        public AMGraphic(string _uniqueid, IGeometry _geometry, bool _isTemp = false)
+        public AMGraphic(string _uniqueid, IGeometry _geometry, bool _isTemp = false, Dictionary<string, Tuple<object, bool>> _dictionary = null)
         {
             UniqueId = _uniqueid;
             Geometry = _geometry;
             IsTemp = _isTemp;
+            FieldsDictionary = _dictionary;
         }
 
         // properties   
@@ -41,6 +44,8 @@ namespace ArcMapAddinCoordinateConversion.Models
         /// Property to determine if graphic is temporary or not
         /// </summary>
         public bool IsTemp { get; set; }
+
+        public Dictionary<string, Tuple<object, bool>> FieldsDictionary;
 
     }
 }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AddInPoint.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/Models/AddInPoint.cs
@@ -15,6 +15,8 @@
 using ESRI.ArcGIS.Geometry;
 using CoordinateConversionLibrary.Helpers;
 using ArcMapAddinCoordinateConversion.ValueConverters;
+using System.Collections.Generic;
+using System;
 
 namespace ArcMapAddinCoordinateConversion.Models
 {
@@ -44,17 +46,17 @@ namespace ArcMapAddinCoordinateConversion.Models
         }
         public string Text
         {
-            get 
-            {   
+            get
+            {
                 try
                 {
-                    return pointConverter.Convert(point as object, typeof(string), null, null) as string; 
+                    return pointConverter.Convert(point as object, typeof(string), null, null) as string;
                 }
                 catch
                 {
                     return "NA";
                 }
-                
+
             }
         }
 
@@ -86,6 +88,13 @@ namespace ArcMapAddinCoordinateConversion.Models
                 isSelected = value;
                 RaisePropertyChanged(() => IsSelected);
             }
+        }
+
+        private Dictionary<string, Tuple<object,bool>> fieldsDictionary;
+        public Dictionary<string, Tuple<object, bool>> FieldsDictionary
+        {
+            get { return fieldsDictionary; }
+            set { fieldsDictionary = value; }
         }
     }
 }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
@@ -55,6 +55,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             ViewDetailCommand = new RelayCommand(OnViewDetailCommand);
 
             FieldsCollection = new ObservableCollection<CoordinateConversionLibrary.ViewModels.FieldsCollection>();
+            ViewDetailsTitle = string.Empty;
             Mediator.Register(CoordinateConversionLibrary.Constants.NewMapPointSelection, OnNewMapPointSelection);
             Mediator.Register(CoordinateConversionLibrary.Constants.RequestCoordinateBroadcast, OnBCNeeded);
 
@@ -67,6 +68,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         public CoordinateType InputCoordinateType { get; set; }
         public ICommandItem CurrentTool { get; set; }
         public ObservableCollection<FieldsCollection> FieldsCollection { get; set; }
+        public string ViewDetailsTitle { get; set; }
 
         public static ArcMapCoordinateGet amCoordGetter = new ArcMapCoordinateGet();
 
@@ -183,8 +185,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             }
             var valOutput = dictionary.Where(x => x.Key == PointFieldName).Select(x => x.Value.Item1).FirstOrDefault();
             IPointToStringConverter pointConverter = new IPointToStringConverter();
-            var outputString = pointConverter.Convert(valOutput, typeof(string), null, null) as string;
-            FieldsCollection.Add(new FieldsCollection() { FieldName = OutputFieldName, FieldValue = outputString });
+            ViewDetailsTitle = pointConverter.Convert(valOutput, typeof(string), null, null) as string;
             var diag = new AdditionalFieldsView();
             diag.DataContext = this;
             diag.ShowDialog();

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -38,8 +38,8 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
     {
         public CollectTabViewModel()
         {
-            ListBoxItemAddInPoint = null;  
-          
+            ListBoxItemAddInPoint = null;
+
             CoordinateAddInPoints = new ObservableCollection<AddInPoint>();
 
             DeletePointCommand = new RelayCommand(OnDeletePointCommand);
@@ -85,7 +85,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
         public AddInPoint ListBoxItemAddInPoint { get; set; }
 
-        public static ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }       
+        public static ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }
 
         private object _ListBoxSelectedItem = null;
         public object ListBoxSelectedItem
@@ -174,7 +174,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         }
 
         // copy parameter to clipboard
-        private void OnCopyCommand(object obj)
+        public override void OnCopyCommand(object obj)
         {
             var items = obj as IList;
             if (items == null)
@@ -234,7 +234,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                     {
                         string kmlName = System.IO.Path.GetFileName(path);
                         string folderName = System.IO.Path.GetDirectoryName(path);
-                        string tempShapeFile = folderName + System.IO.Path.DirectorySeparatorChar + 
+                        string tempShapeFile = folderName + System.IO.Path.DirectorySeparatorChar +
                             "tmpShapefile.shp";
                         var grpList = GetMapPointExportFormat(GraphicsList);
                         IFeatureClass tempFc = fcUtils.CreateFCOutput(tempShapeFile, SaveAsType.Shapefile, grpList, ArcMap.Document.FocusMap.SpatialReference);
@@ -258,24 +258,29 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                         string csvName = System.IO.Path.GetFileName(path);
                         string folderName = System.IO.Path.GetDirectoryName(path);
                         string tempFile = System.IO.Path.Combine(folderName, csvName);
-
                         var aiPoints = CoordinateAddInPoints.ToList();
-
                         if (!aiPoints.Any())
                             return;
-
                         var csvExport = new CsvExport();
+                        var displayAmb = CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg;
                         foreach (var point in aiPoints)
                         {
                             var results = GetOutputFormats(point);
                             csvExport.AddRow();
-                            foreach (KeyValuePair<string, string> format in results)
+                            foreach (var item in results)
+                                csvExport[item.Key] = item.Value;
+                            if (point.FieldsDictionary != null)
                             {
-                                csvExport[format.Key] = format.Value;
+                                foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
+                                {
+                                    if (item.Key != PointFieldName && item.Key != OutputFieldName)
+                                        csvExport[item.Key] = item.Value;
+                                }
                             }
+                            CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
                         }
+                        CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = displayAmb;
                         csvExport.ExportToFile(tempFile);
-
                         System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.CSVExportSuccessfulMessage + tempFile,
                             CoordinateConversionLibrary.Properties.Resources.CSVExportSuccessfulCaption);
                     }
@@ -297,7 +302,13 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                 if (pt == null)
                     continue;
 
-                var attributes = GetOutputFormats(new AddInPoint() { Point= pt});
+                var attributes = GetOutputFormats(new AddInPoint() { Point = pt });
+                if (point.FieldsDictionary != null)
+                {
+                    foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
+                        if (item.Key != PointFieldName && item.Key != OutputFieldName)
+                            attributes[item.Key] = Convert.ToString(item.Value);
+                }
                 CCAMGraphic ccMapPoint = new CCAMGraphic() { Attributes = attributes, MapPoint = point };
                 results.Add(ccMapPoint);
             }
@@ -462,14 +473,15 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                                 var simpleMarkerSymbol = (ISimpleMarkerSymbol)new SimpleMarkerSymbol();
 
                                 simpleMarkerSymbol.Color = sms.Color;
-                                simpleMarkerSymbol.Size = sms.Size;
+                                simpleMarkerSymbol.Size = ArcMapHelpers.DefaultMarkerSize;
                                 simpleMarkerSymbol.Style = sms.Style;
-                                simpleMarkerSymbol.OutlineSize = 1;
+                                simpleMarkerSymbol.OutlineSize = 1.7;
 
                                 if (aiPoint.IsSelected)
                                 {
                                     var color = (IColor)new RgbColorClass() { Green = 255 };
                                     // Marker symbols
+                                    simpleMarkerSymbol.Size = ArcMapHelpers.DefaultMarkerSize + ArcMapHelpers.DefaultOutlineSize;
                                     simpleMarkerSymbol.Outline = true;
                                     simpleMarkerSymbol.OutlineColor = color;
                                     doUpdate = true;
@@ -498,18 +510,18 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             av.Refresh();
         }
 
-        private void AddCollectionPoint(IPoint point)
+        private void AddCollectionPoint(IPoint point, Dictionary<string, Tuple<object, bool>> fieldsDictionary = null)
         {
             if (point != null && !point.IsEmpty)
             {
                 var color = (IColor)new RgbColorClass() { Red = 255 };
                 var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
-                var addInPoint = new AddInPoint() { Point = point, GUID = guid };
+                var addInPoint = new AddInPoint() { Point = point, GUID = guid, FieldsDictionary = fieldsDictionary };
 
                 //Add point to the top of the list
                 CoordinateAddInPoints.Insert(0, addInPoint);
 
-                GraphicsList.Add(new AMGraphic(guid, point, true));
+                GraphicsList.Add(new AMGraphic(guid, point, true, fieldsDictionary));
             }
         }
 
@@ -558,17 +570,37 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
         private void OnImportCoordinates(object obj)
         {
-            var coordinates = obj as List<string>;
-            if (coordinates == null)
+            if (obj == null)
                 return;
-
-            foreach (var coordinate in coordinates)
+            var input = obj as List<Dictionary<string, Tuple<object, bool>>>;
+            if (input != null)
+                foreach (var item in input)
+                {
+                    var coordinate = item.Where(x => x.Key == OutputFieldName).Select(x => Convert.ToString(x.Value.Item1)).FirstOrDefault();
+                    if (coordinate == "" || item.Where(x => x.Key == PointFieldName).Any())
+                        continue;
+                    this.ProcessInput(coordinate);
+                    InputCoordinate = coordinate;
+                    if (!HasInputError)
+                    {
+                        item.Add(PointFieldName, Tuple.Create((object)amCoordGetter.Point, false));
+                        OnNewMapPoint(item);
+                    }
+                }
+            else
             {
-                this.ProcessInput(coordinate);
-                InputCoordinate = coordinate;
-                if (!HasInputError)
-                    OnNewMapPoint(amCoordGetter.Point);
+                List<string> coordinates = obj as List<string>;
+                if (coordinates == null)
+                    return;
+                foreach (var coordinate in coordinates)
+                {
+                    this.ProcessInput(coordinate);
+                    InputCoordinate = coordinate;
+                    if (!HasInputError)
+                        OnNewMapPoint(amCoordGetter.Point);
+                }
             }
+            RaisePropertyChanged(() => CoordinateAddInPoints);
         }
 
         private void ClearGraphicsContainer(IMap map)
@@ -589,7 +621,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             }
         }
 
-        private void OnPasteCommand(object obj)
+        public override void OnPasteCommand(object obj)
         {
             var input = Clipboard.GetText().Trim();
             string[] lines = input.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
@@ -624,7 +656,9 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             if (!base.OnNewMapPoint(obj))
                 return false;
 
-            AddCollectionPoint(obj as IPoint);
+            var input = obj as Dictionary<string, Tuple<object, bool>>;
+            IPoint point = (input != null) ? input.Where(x => x.Key == PointFieldName).Select(x => x.Value.Item1).FirstOrDefault() as IPoint : obj as IPoint;
+            AddCollectionPoint(point as IPoint, input);
 
             return true;
         }
@@ -641,7 +675,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         }
 
         public override void OnMapPointSelection(object obj)
-        {          
+        {
             var mapPoint = obj as IPoint;
             mapPoint.Project(ArcMap.Document.FocusMap.SpatialReference);
             ITopologicalOperator topoOp = (ITopologicalOperator)mapPoint;
@@ -672,7 +706,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                 closestPoint.IsSelected = true;
                 ListBoxSelectedItem = closestPoint;
             }
-            RaisePropertyChanged(() => ListBoxSelectedItem);            
+            RaisePropertyChanged(() => ListBoxSelectedItem);
         }
 
         #endregion overrides

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -100,6 +100,9 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
                 // update selections
                 UpdateHighlightedGraphics();
+                var addinPoint = CoordinateAddInPoints.Where(x => x.IsSelected).FirstOrDefault();
+                amCoordGetter.Point = addinPoint.Point;
+                Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.RequestOutputUpdate, null);
             }
         }
 
@@ -274,7 +277,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                                 foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
                                 {
                                     if (item.Key != PointFieldName && item.Key != OutputFieldName)
-                                        csvExport[item.Key] = item.Value;
+                                        csvExport[item.Key] = item.Value.Item1;
                                 }
                             }
                             CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
@@ -307,7 +310,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                 {
                     foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
                         if (item.Key != PointFieldName && item.Key != OutputFieldName)
-                            attributes[item.Key] = Convert.ToString(item.Value);
+                            attributes[item.Key] = Convert.ToString(item.Value.Item1);
                 }
                 CCAMGraphic ccMapPoint = new CCAMGraphic() { Attributes = attributes, MapPoint = point };
                 results.Add(ccMapPoint);
@@ -520,7 +523,8 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
                 //Add point to the top of the list
                 CoordinateAddInPoints.Insert(0, addInPoint);
-
+                CoordinateAddInPoints.ToList().ForEach(x => x.IsSelected = false);
+                CoordinateAddInPoints.ElementAt(0).IsSelected = true;
                 GraphicsList.Add(new AMGraphic(guid, point, true, fieldsDictionary));
             }
         }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -523,8 +523,6 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
 
                 //Add point to the top of the list
                 CoordinateAddInPoints.Insert(0, addInPoint);
-                CoordinateAddInPoints.ToList().ForEach(x => x.IsSelected = false);
-                CoordinateAddInPoints.ElementAt(0).IsSelected = true;
                 GraphicsList.Add(new AMGraphic(guid, point, true, fieldsDictionary));
             }
         }

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
@@ -223,7 +223,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             if (point != null && !point.IsEmpty)
             {
                 var color = new RgbColorClass() { Red = 255 } as IColor;
-                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, 7);
+                var guid = ArcMapHelpers.AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSCircle, ArcMapHelpers.DefaultMarkerSize);
                 var addInPoint = new AddInPoint() { Point = point, GUID = guid };
 
                 //Add point to the top of the list

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ConvertTabViewModel.cs
@@ -42,7 +42,8 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             CollectTabView.DataContext = new CollectTabViewModel();
 
             InputCoordinateHistoryList = new ObservableCollection<string>();
-        }
+            Mediator.Register(CoordinateConversionLibrary.Constants.DEACTIVATE_TOOL, OnDeactivateTool);
+        }      
 
         public InputCoordinateConversionView InputCCView { get; set; }
         public OutputCoordinateView OutputCCView { get; set; }
@@ -217,6 +218,11 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         }
 
         #endregion overrides
+
+        public void OnDeactivateTool(object obj)
+        {
+            IsToolActive = false;
+        }
 
         private void AddCollectionPoint(IPoint point)
         {

--- a/source/CoordinateConversion/CoordinateConversionLibrary/CoordinateConversionLibrary.csproj
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/CoordinateConversionLibrary.csproj
@@ -89,6 +89,9 @@
     <Compile Include="ViewModels\OutputCoordinateViewModel.cs" />
     <Compile Include="ViewModels\SelectCoordinateFieldsViewModel.cs" />
     <Compile Include="ViewModels\TabBaseViewModel.cs" />
+    <Compile Include="Views\AdditionalFieldsView.xaml.cs">
+      <DependentUpon>AdditionalFieldsView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\CCCollectTabView.xaml.cs">
       <DependentUpon>CCCollectTabView.xaml</DependentUpon>
     </Compile>
@@ -119,6 +122,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="MAResourceDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\AdditionalFieldsView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/Constants.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/Constants.cs
@@ -37,5 +37,6 @@ namespace CoordinateConversionLibrary
         public const string IMPORT_COORDINATES = "IMPORT_COORDINATES";
         public const string CollectListHasItems = "COLLECT_LIST_HAS_ITEMS";
         public const string SELECT_MAP_POINT = "SELECT_MAP_POINT";
+        public const string DEACTIVATE_TOOL = "DEACTIVATE_TOOL";
     }
 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/MAResourceDictionary.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/MAResourceDictionary.xaml
@@ -6,9 +6,9 @@
     <Style x:Key="BorderedButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="BorderBrush" Value="#9FCDE8"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Foreground" Value="#FFFFFF"/>
+        <Setter Property="Foreground" Value="{DynamicResource Esri_TextControlBrush}"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Template">
@@ -28,19 +28,20 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Foreground" Value="#FFFFFF" />
+                            <Setter Property="BorderBrush" Value="#9FCDE8" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderBrush}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="#E2F1FB" />
+                            <Setter Property="Background" Value="{DynamicResource Esri_BackgroundHoverBrush}" />
                             <Setter Property="BorderBrush" Value="#9FCDE8" />
-                            <Setter Property="Foreground" Value="#FFFFFF" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter Property="Background" Value="#90CDF2" />
+                            <Setter Property="Background" Value="{DynamicResource Esri_BackgroundPressedBrush}" />
                             <Setter Property="BorderBrush" Value="#007AC2"/>
-                            <Setter Property="Foreground" Value="#FFFFFF"/>
-                        </Trigger>
-                        <Trigger Property="IsFocused" Value="true">
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#007AC2" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderPressedBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -50,9 +51,9 @@
     <Style x:Key="BorderedTButtonStyle" TargetType="{x:Type ToggleButton}">
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="BorderBrush" Value="#9FCDE8"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Foreground" Value="#FFFFFF"/>
+        <Setter Property="Foreground" Value="{DynamicResource Esri_TextControlBrush}"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Template">
@@ -69,27 +70,29 @@
                                     RecognizesAccessKey="True"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                     </Border>
+
+
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Foreground" Value="#FFFFFF" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="#E2F1FB" />
+                            <Setter Property="Background" Value="{DynamicResource Esri_BackgroundHoverBrush}" />
                             <Setter Property="BorderBrush" Value="#9FCDE8" />
-                            <Setter Property="Foreground" Value="#FFFFFF" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter Property="Background" Value="#90CDF2" />
+                            <Setter Property="Background" Value="{DynamicResource Esri_BackgroundPressedBrush}" />
                             <Setter Property="BorderBrush" Value="#007AC2"/>
-                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderPressedBrush}"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
                             <Setter Property="Background" Value="#90CDF2" />
-                            <Setter Property="BorderBrush" Value="#1ba1e2"/>
-                            <Setter Property="Foreground" Value="#FFFFFF"/>
-                        </Trigger>
-                        <Trigger Property="IsFocused" Value="true">
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#007AC2" />
+                            <Setter Property="Background" Value="{DynamicResource Esri_BackgroundPressedBrush}" />
+                            <Setter Property="BorderBrush" Value="#1888cd"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderPressedBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -139,6 +142,12 @@
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value="0.5"/>
                 <Setter Property="Background" Value="Transparent"/>
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#E2F1FB" />
+                <Setter Property="Background" Value="{DynamicResource Esri_BackgroundHoverBrush}" />
+                <Setter Property="BorderBrush" Value="#9FCDE8" />
+                <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderHoverBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Models/CoordinateDDM.cs
@@ -289,17 +289,16 @@ namespace CoordinateConversionLibrary.Models
                                     sb.Append("+");
                                 break;
                             case '-':
-                                if (isHyphenFirstCharacter)
+                                if (isHyphenFirstCharacter || cnum < 0.0)
                                 {
-                                    if (cnum < 0.0)
-                                        sb.Append("-");
-
+                                    //if (cnum < 0.0)
+                                    sb.Append("-");
                                     isHyphenFirstCharacter = false;
                                 }
-                                else
-                                {
-                                    sb.Append("-");
-                                }
+                                //else
+                                //{
+                                //    sb.Append("-");
+                                //}
                                 break;
                             case 'N': // N or S
                             case 'S':

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.Designer.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.Designer.cs
@@ -851,5 +851,14 @@ namespace CoordinateConversionLibrary.Properties {
                 return ResourceManager.GetString("UseTwoFields", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View Details.
+        /// </summary>
+        public static string ViewDetails {
+            get {
+                return ResourceManager.GetString("ViewDetails", resourceCulture);
+            }
+        }
     }
 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.resx
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.resx
@@ -381,4 +381,7 @@
   <data name="MsgNoDataFound" xml:space="preserve">
     <value>No data found.</value>
   </data>
+  <data name="ViewDetails" xml:space="preserve">
+    <value>View Details</value>
+  </data>
 </root>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/OutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/OutputCoordinateViewModel.cs
@@ -318,24 +318,42 @@ namespace CoordinateConversionLibrary.ViewModels
                     var temp = dt;
                     foreach (DataRow item in dt.Rows)
                     {
-                        CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Add(
-                        new OutputCoordinateModel()
+                        string itemName = Convert.ToString(item["Name"]);
+                        var coordFormats = CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Where(x => x.Name == itemName).ToList();
+                        if (coordFormats.Count > 0)
                         {
-                            CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"])),
-                            DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"])),
-                            Format = Convert.ToString(item["Format"]),
-                            Name = Convert.ToString(item["Name"]),
-                            OutputCoordinate = Convert.ToString(item["OutputCoordinate"]),
-                            SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]),
-                            SRName = Convert.ToString(item["SRName"])
-                        });
+                            CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Where(x => x.Name == itemName).Select(x =>
+                            {
+                                x.CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"]));
+                                x.DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"]));
+                                x.Format = Convert.ToString(item["Format"]);
+                                x.OutputCoordinate = Convert.ToString(item["OutputCoordinate"]);
+                                x.SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]);
+                                x.SRName = Convert.ToString(item["SRName"]);
+                                return x;
+                            }).ToList();
+                        }
+                        else
+                        {
+                            CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Add(
+                            new OutputCoordinateModel()
+                            {
+                                CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"])),
+                                DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"])),
+                                Format = Convert.ToString(item["Format"]),
+                                Name = itemName,
+                                OutputCoordinate = Convert.ToString(item["OutputCoordinate"]),
+                                SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]),
+                                SRName = Convert.ToString(item["SRName"])
+                            });
+                        }
                     }
                 }
             }
             catch (Exception)
             {
                 MessageBox.Show("Something went wrong.");
-            }    
+            }
         }
 
         public virtual void OnResetButtonCommand(object obj)
@@ -387,7 +405,7 @@ namespace CoordinateConversionLibrary.ViewModels
             }
             catch (Exception)
             {
-            }            
+            }
         }
         #endregion
 

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/SelectCoordinateFieldsViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/SelectCoordinateFieldsViewModel.cs
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using CoordinateConversionLibrary.Helpers;
+using System.Windows.Controls;
 
 namespace CoordinateConversionLibrary.ViewModels
 {
@@ -23,10 +24,12 @@ namespace CoordinateConversionLibrary.ViewModels
         public SelectCoordinateFieldsViewModel()
         {
             AvailableFields = new ObservableCollection<string>();
+            FieldCollection = new ObservableCollection<ListBoxItem>();
             SelectedFields = new List<string>();
             OKButtonPressedCommand = new RelayCommand(OnOkButtonPressedCommand);
         }
         public ObservableCollection<string> AvailableFields { get; set; }
+        public ObservableCollection<ListBoxItem> FieldCollection { get; set; }
         public List<string> SelectedFields { get; set; }
         private bool useTwoFields = false;
         public bool UseTwoFields

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/TabBaseViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/TabBaseViewModel.cs
@@ -16,11 +16,14 @@ using System;
 using CoordinateConversionLibrary.Helpers;
 using CoordinateConversionLibrary.Models;
 using CoordinateConversionLibrary.Views;
-using Microsoft.Win32;
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using System.Linq;
+using System.Collections.ObjectModel;
+using System.Windows.Controls;
+using System.Diagnostics;
 
 namespace CoordinateConversionLibrary.ViewModels
 {
@@ -31,11 +34,15 @@ namespace CoordinateConversionLibrary.ViewModels
             HasInputError = false;
             IsHistoryUpdate = true;
             IsToolGenerated = false;
-            
+
             // commands
             EditPropertiesDialogCommand = new RelayCommand(OnEditPropertiesDialogCommand);
             ImportCSVFileCommand = new RelayCommand(OnImportCSVFileCommand);
+            CopyCommand = new RelayCommand(OnCopyCommand);
+            PasteCommand = new RelayCommand(OnPasteCommand);
 
+            ListDictionary = new List<Dictionary<string, Tuple<object, bool>>>();
+            FieldCollection = new List<object>();
             Mediator.Register(CoordinateConversionLibrary.Constants.NEW_MAP_POINT, OnNewMapPointInternal);
             Mediator.Register(CoordinateConversionLibrary.Constants.MOUSE_MOVE_POINT, OnMouseMoveInternal);
             Mediator.Register(CoordinateConversionLibrary.Constants.SELECT_MAP_POINT, OnSelectMapPointInternal);
@@ -47,8 +54,19 @@ namespace CoordinateConversionLibrary.ViewModels
 
         public RelayCommand EditPropertiesDialogCommand { get; set; }
         public RelayCommand ImportCSVFileCommand { get; set; }
+        public RelayCommand CopyCommand { get; set; }
+        public RelayCommand PasteCommand { get; set; }
 
         //TODO is this used anymore?
+        public static string OutputFieldName = "OutputCoordinate";
+        public static string PointFieldName = "Point";
+        public static string CoordinateFieldName = "Coordinate";
+        public static string SelectedField1 = "";
+        public static string SelectedField2 = "";
+        public static List<object> FieldCollection { get; set; }
+        public static List<Dictionary<string, Tuple<object, bool>>> ImportedData { get; set; }
+        public static List<Dictionary<string, Tuple<object, bool>>> ListDictionary { get; set; }
+        public ObservableCollection<ListBoxItem> SelectedFieldItem { get; set; }
         public bool IsHistoryUpdate { get; set; }
 
         private bool _hasInputError = false;
@@ -121,63 +139,223 @@ namespace CoordinateConversionLibrary.ViewModels
 
         }
 
+        public virtual void OnCopyCommand(object obj)
+        {
+        }
+
+        public virtual void OnPasteCommand(object obj)
+        {
+        }
+
+        public virtual bool CheckMapLoaded()
+        {
+            return false;
+        }
+
         public virtual void OnImportCSVFileCommand(object obj)
         {
-            CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
-
-            var fileDialog = new Microsoft.Win32.OpenFileDialog();
-            fileDialog.CheckFileExists = true;
-            fileDialog.CheckPathExists = true;
-            fileDialog.Filter = "csv files|*.csv";
-
-            // attemp to import
-            var fieldVM = new SelectCoordinateFieldsViewModel();
-            var result = fileDialog.ShowDialog();
-            if (result.HasValue && result.Value == true)
+            try
             {
-                var dlg = new SelectCoordinateFieldsView();
-                using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                Cursor.Current = Cursors.WaitCursor;
+                if (CheckMapLoaded())
                 {
-                    var headers = ImportCSV.GetHeaders(s);
-                    if (headers != null)
+                    CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
+                    var fileDialog = new Microsoft.Win32.OpenFileDialog();
+                    fileDialog.CheckFileExists = true;
+                    fileDialog.CheckPathExists = true;
+                    fileDialog.Filter = "csv files|*.csv|Excel 97-2003 Workbook (*.xls)|*.xls|Excel Workbook (*.xlsx)|*.xlsx";
+                    // attemp to import
+                    var fieldVM = new SelectCoordinateFieldsViewModel();
+                    var result = fileDialog.ShowDialog();
+                    if (result.HasValue && result.Value == true)
                     {
-                        foreach (var header in headers)
-                        {
-                            fieldVM.AvailableFields.Add(header);
-                            System.Diagnostics.Debug.WriteLine("header : {0}", header);
-                        }
+                        var dlg = new SelectCoordinateFieldsView();
 
-                        dlg.DataContext = fieldVM;
+                        var coordinates = new List<string>();
+                        var extension = Path.GetExtension(fileDialog.FileName);
+                        switch (extension)
+                        {
+                            case ".csv":
+                                ImportFromCSV(fieldVM, dlg, coordinates, fileDialog.FileName);
+                                break;
+                            case ".xls":
+                            case ".xlsx":
+                                ImportFromExcel(dlg, fileDialog, fieldVM);
+                                break;
+                            default:
+                                break;
+                        }
                     }
-                    else
+                    CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = true;
+                }
+                else
+                {
+                    System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.AddLayerMsg,
+                        CoordinateConversionLibrary.Properties.Resources.AddLayerCap);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Something went wrong.");
+                Debug.WriteLine("OnImportCSVFileCommand Error " + ex.ToString());
+            }
+        }
+
+        private void ImportFromCSV(SelectCoordinateFieldsViewModel fieldVM, SelectCoordinateFieldsView dlg, List<string> coordinates, string fileName)
+        {
+            using (Stream s = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                var headers = ImportCSV.GetHeaders(s);
+                ImportedData = new List<Dictionary<string, Tuple<object, bool>>>();
+                if (headers != null)
+                {
+                    foreach (var header in headers)
                     {
-                        System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.MsgNoDataFound);
-                        return;
+                        fieldVM.AvailableFields.Add(header);
+                        fieldVM.FieldCollection.Add(new ListBoxItem() { Name = header, Content = header, IsSelected = false });
+                        System.Diagnostics.Debug.WriteLine("header : {0}", header);
                     }
+                    dlg.DataContext = fieldVM;
+                }
+                else
+                {
+                    System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.MsgNoDataFound);
+                    return;
                 }
                 if (dlg.ShowDialog() == true)
                 {
-                    using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    var dictionary = new List<Dictionary<string, Tuple<object, bool>>>();
+
+                    using (Stream str = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                     {
-                        var lists = ImportCSV.Import<ImportCoordinatesList>(s, fieldVM.SelectedFields.ToArray());
-                        var coordinates = new List<string>();
-
-                        foreach (var item in lists)
+                        var lists = ImportCSV.Import<ImportCoordinatesList>(str, fieldVM.SelectedFields.ToArray(), headers, dictionary);
+                        FieldCollection = fieldVM.FieldCollection.Where(y => y.IsSelected).Select(x => x.Content).ToList();
+                        foreach (var item in dictionary)
                         {
-                            var sb = new StringBuilder();
-                            sb.Append(item.lat.Trim());
-                            if (fieldVM.UseTwoFields)
-                                sb.Append(string.Format(" {0}", item.lon.Trim()));
-
-                            coordinates.Add(sb.ToString());
+                            var dict = new Dictionary<string, Tuple<object, bool>>();
+                            foreach (var field in item)
+                            {
+                                if (FieldCollection.Contains(field.Key) || fieldVM.SelectedFields.ToArray()[0] == field.Key)
+                                {
+                                    dict.Add(field.Key, Tuple.Create((object)field.Value.Item1, FieldCollection.Contains(field.Key)));
+                                    if (fieldVM.SelectedFields.ToArray()[0] == field.Key)
+                                        SelectedField1 = Convert.ToString(field.Key);
+                                }
+                                else if (fieldVM.UseTwoFields)
+                                    if (fieldVM.SelectedFields.ToArray()[1] == field.Key)
+                                    {
+                                        dict.Add(field.Key, Tuple.Create((object)field.Value.Item1, FieldCollection.Contains(field.Key)));
+                                        SelectedField2 = Convert.ToString(field.Key);
+                                    }
+                            }
+                            ImportedData.Add(dict);
                         }
-
-                        Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.IMPORT_COORDINATES, coordinates);
+                        foreach (var item in ImportedData)
+                        {
+                            var lat = item.Where(x => x.Key == fieldVM.SelectedFields.ToArray()[0]).Select(x => x.Value.Item1).FirstOrDefault();
+                            var sb = new StringBuilder();
+                            sb.Append(lat);
+                            if (fieldVM.UseTwoFields)
+                            {
+                                var lon = item.Where(x => x.Key == fieldVM.SelectedFields.ToArray()[1]).Select(x => x.Value.Item1).FirstOrDefault();
+                                sb.Append(string.Format(" {0}", lon));
+                            }
+                            item.Add(OutputFieldName, Tuple.Create((object)sb.ToString(), false));
+                            ListDictionary.Add(item);
+                        }
                     }
+                    Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.IMPORT_COORDINATES, ListDictionary);
                 }
             }
+        }
 
-            CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = true;
+        public void ImportFromExcel(SelectCoordinateFieldsView dlg, Microsoft.Win32.OpenFileDialog diag, SelectCoordinateFieldsViewModel fieldVM)
+        {
+            ImportedData = new List<Dictionary<string, Tuple<object, bool>>>();
+            List<string> headers = new List<string>();
+            FieldCollection = new List<object>();
+            var filename = diag.FileName;
+            string selectedCol1Key = "", selectedCol2Key = "";
+            var selectedColumn = fieldVM.SelectedFields.ToArray();
+            var lstDictonary = new List<Dictionary<string, Tuple<object, bool>>>();
+            var columnCollection = new List<string>();
+            var fileExt = Path.GetExtension(filename); //get the extension of uploaded excel file
+            var lstDictionary = ReadExcelInput(filename);
+
+            var firstDict = lstDictionary.FirstOrDefault();
+            headers = firstDict.Where(x => x.Key != "OBJECTID").Select(x => x.Key).ToList<string>();
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    fieldVM.AvailableFields.Add(header.Replace(" ", ""));
+                    fieldVM.FieldCollection.Add(new ListBoxItem() { Name = header.Replace(" ", ""), Content = header, IsSelected = false });
+                }
+                dlg.DataContext = fieldVM;
+            }
+            else
+            {
+                System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.MsgNoDataFound);
+            }
+            if (dlg.ShowDialog() == true)
+            {
+
+                foreach (var item in headers)
+                {
+                    columnCollection.Add(item);
+                    if (item == fieldVM.SelectedFields.ToArray()[0])
+                    {
+                        SelectedField1 = item;
+                        selectedCol1Key = item;
+                    }
+                    if (fieldVM.UseTwoFields)
+                    {
+                        if (item == fieldVM.SelectedFields.ToArray()[1])
+                        {
+                            SelectedField2 = item;
+                            selectedCol2Key = item;
+                        }
+                    }
+                    continue;
+                }
+                for (int i = 0; i < lstDictionary.Count; i++)
+                {
+                    var dict = new Dictionary<string, Tuple<object, bool>>();
+                    dict = lstDictionary[i];
+                    if (fieldVM.UseTwoFields)
+                    {
+                        if (lstDictionary[i].Where(x => x.Key == selectedCol1Key) != null && lstDictionary[i].Where(x => x.Key == selectedCol2Key) != null)
+                            dict.Add(OutputFieldName, Tuple.Create((object)Convert.ToString(lstDictionary[i].Where(x => x.Key == selectedCol1Key).Select(x => x.Value.Item1).FirstOrDefault()
+                                + " " + lstDictionary[i].Where(x => x.Key == selectedCol2Key).Select(x => x.Value.Item1).FirstOrDefault()), false));
+                    }
+                    else
+                    {
+                        if (lstDictionary[i].Where(x => x.Key == selectedCol1Key) != null)
+                            dict.Add(OutputFieldName, Tuple.Create((object)lstDictionary[i].Where(x => x.Key == selectedCol1Key).Select(x => x.Value.Item1).FirstOrDefault(), false));
+                    }
+                    ImportedData.Add(dict);
+                }
+                FieldCollection = fieldVM.FieldCollection.Where(y => y.IsSelected).Select(x => x.Content).ToList();
+                foreach (var item in ImportedData)
+                {
+                    var dict = new Dictionary<string, Tuple<object, bool>>();
+                    foreach (var field in item)
+                    {
+                        if (FieldCollection.Contains(field.Key) || fieldVM.SelectedFields.ToArray()[0] == field.Key || field.Key == OutputFieldName)
+                            dict.Add(field.Key, Tuple.Create(field.Value.Item1, FieldCollection.Contains(field.Key)));
+                        else if (fieldVM.UseTwoFields)
+                            if (fieldVM.SelectedFields.ToArray()[1] == field.Key)
+                                dict.Add(field.Key, Tuple.Create(field.Value.Item1, FieldCollection.Contains(field.Key)));
+                    }
+                    lstDictonary.Add(dict);
+                }
+                Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.IMPORT_COORDINATES, lstDictonary);
+            }
+        }
+
+        public virtual List<Dictionary<string, Tuple<object, bool>>> ReadExcelInput(string fileName)
+        {
+            return new List<Dictionary<string, Tuple<object, bool>>>();
         }
 
         private void OnNewMapPointInternal(object obj)
@@ -216,5 +394,11 @@ namespace CoordinateConversionLibrary.ViewModels
     {
         public string lat { get; set; }
         public string lon { get; set; }
+    }
+
+    public class FieldsCollection
+    {
+        public string FieldName { get; set; }
+        public string FieldValue { get; set; }
     }
 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/TabBaseViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/TabBaseViewModel.cs
@@ -151,12 +151,12 @@ namespace CoordinateConversionLibrary.ViewModels
         {
             return false;
         }
-
+        
         public virtual void OnImportCSVFileCommand(object obj)
         {
             try
             {
-                Cursor.Current = Cursors.WaitCursor;
+                Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.DEACTIVATE_TOOL, null);
                 if (CheckMapLoaded())
                 {
                     CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml
@@ -7,7 +7,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:prop="clr-namespace:CoordinateConversionLibrary.Properties"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        Title="Additional Fields"
+        Title="{Binding ViewDetailsTitle}"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml
@@ -1,0 +1,39 @@
+﻿<Window x:Class="CoordinateConversionLibrary.Views.AdditionalFieldsView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:helpers="clr-namespace:CoordinateConversionLibrary.Helpers"
+        xmlns:local="clr-namespace:CoordinateConversionLibrary"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:prop="clr-namespace:CoordinateConversionLibrary.Properties"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        Title="Additional Fields"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+        helpers:DialogCloser.DialogResult="{Binding DialogResult}"
+        mc:Ignorable="d">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/CoordinateConversionLibrary;component/MAResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid>
+        <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding FieldsCollection}" HorizontalAlignment="Left"
+            CanUserAddRows="False"
+            CanUserDeleteRows="False"
+            CanUserReorderColumns="False"
+            CanUserResizeRows="False"
+            CanUserSortColumns="False"
+                  HeadersVisibility="Column"
+                  RowHeight="25"
+                  Name="dgTripwire" VerticalAlignment="Top">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Field Name" Binding="{Binding Path=FieldName}" FontWeight="Bold" />
+                <DataGridTextColumn Header="Field Value" Binding="{Binding Path=FieldValue}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</Window>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/AdditionalFieldsView.xaml.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2016 Esri 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Windows;
+
+namespace CoordinateConversionLibrary.Views
+{
+    /// <summary>
+    /// Interaction logic for SelectCoordinateFieldsDialog.xaml
+    /// </summary>
+    public partial class AdditionalFieldsView : Window
+    {
+        public AdditionalFieldsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
@@ -74,6 +74,7 @@
             ItemsSource="{Binding CoordinateAddInPoints}"
             SelectedIndex="{Binding ListBoxSelectedIndex}"
             SelectedItem="{Binding ListBoxSelectedItem}"
+            PreviewMouseDown="listBoxCoordinates_PreviewMouseDown" 
             SelectionMode="Extended">
             <ListBox.ItemTemplate>
                 <DataTemplate>
@@ -110,6 +111,11 @@
                     <MenuItem
                         Command="{Binding DataContext.PasteCoordinatesCommand}"
                         Header="Paste"/>
+                    <MenuItem
+                        Command="{Binding DataContext.ViewDetailCommand}"
+                        CommandParameter="{Binding}"
+                        Header="{x:Static prop:Resources.ViewDetails}"
+                        IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>
                 </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.InputBindings>
@@ -117,6 +123,9 @@
                     Key="Delete"
                     Command="{Binding DeletePointCommand}"
                     CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}" />
+                <KeyBinding Modifiers="Control" Key="C" Command="{Binding CopyCommand}"
+                             CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}"/>
+                <KeyBinding Modifiers="Control" Key="V" Command="{Binding PasteCommand}"/>
             </ListBox.InputBindings>
             <ListBox.Style>
                 <Style TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
@@ -68,84 +68,87 @@
                 </Button.Style>
             </Button>
         </StackPanel>
-        <ListBox
+        <Grid x:Name="grdListView" VerticalAlignment="Stretch">
+            <ListBox
             x:Name="listBoxCoordinates"
             MinHeight="40"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
             ItemsSource="{Binding CoordinateAddInPoints}"
             SelectedIndex="{Binding ListBoxSelectedIndex}"
             SelectedItem="{Binding ListBoxSelectedItem}"
             MouseLeftButtonDown="listBoxCoordinates_MouseLeftButtonDown"
             SelectionMode="Extended" 
             MouseRightButtonUp="listBoxCoordinates_MouseRightButtonUp">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Text}"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-            <ListBox.ContextMenu>
-                <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}"
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding Text}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ContextMenu>
+                    <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}"
                              >
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.DeletePointCommand}"
                         CommandParameter="{Binding Path=SelectedItems}"
                         Header="{x:Static prop:Resources.MenuLabelDelete}"
                         IsEnabled="{Binding DataContext.HasAnySelectedItems}" />
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.DeleteAllPointsCommand}"
                         Header="{x:Static prop:Resources.MenuLabelDeleteAll}"
                         IsEnabled="{Binding HasItems}" />
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.FlashPointCommand}"
                         CommandParameter="{Binding}"
                         Header="{x:Static prop:Resources.HeaderFlash}"
                         IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}" />
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.CopyCoordinateCommand}"
                         CommandParameter="{Binding Path=SelectedItems}"
                         Header="{x:Static prop:Resources.MenuLabelCopy}"
                         IsEnabled="{Binding DataContext.HasAnySelectedItems}" />
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.CopyAllCoordinatesCommand}"
                         Header="{x:Static prop:Resources.MenuLabelCopyAll}"
                         IsEnabled="{Binding HasItems}" />
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.PasteCoordinatesCommand}"
                         Header="Paste"/>
-                    <MenuItem
+                        <MenuItem
                         Command="{Binding DataContext.ViewDetailCommand}"
                         CommandParameter="{Binding}"
                         Header="{x:Static prop:Resources.ViewDetails}"
-                        IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>                    
-                </ContextMenu>
-            </ListBox.ContextMenu>
-            <ListBox.InputBindings>
-                <KeyBinding
+                        IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
+                <ListBox.InputBindings>
+                    <KeyBinding
                     Key="Delete"
                     Command="{Binding DeletePointCommand}"
                     CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}" />
-                <KeyBinding Modifiers="Control" Key="C" Command="{Binding CopyCommand}"
+                    <KeyBinding Modifiers="Control" Key="C" Command="{Binding CopyCommand}"
                              CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}"/>
-                <KeyBinding Modifiers="Control" Key="V" Command="{Binding PasteCommand}"/>
-            </ListBox.InputBindings>
-            <ListBox.Style>
-                <Style TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">
-                    <EventSetter Event="PreviewMouseRightButtonDown" Handler="listBox_MouseRightButtonDown" />
-                    <Setter Property="IsEnabled" Value="True" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsRunning}" Value="True">
-                            <Setter Property="IsEnabled" Value="False" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ListBox.Style>
-            <ListBox.ItemContainerStyle>
-                <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-                    <EventSetter Event="PreviewMouseRightButtonDown" Handler="listBoxItem_MouseRightButtonDown" />
-                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
-                </Style>
-            </ListBox.ItemContainerStyle>
-        </ListBox>
+                    <KeyBinding Modifiers="Control" Key="V" Command="{Binding PasteCommand}"/>
+                </ListBox.InputBindings>
+                <ListBox.Style>
+                    <Style TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">
+                        <EventSetter Event="PreviewMouseRightButtonDown" Handler="listBox_MouseRightButtonDown" />
+                        <Setter Property="IsEnabled" Value="True" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsRunning}" Value="True">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ListBox.Style>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                        <EventSetter Event="PreviewMouseRightButtonDown" Handler="listBoxItem_MouseRightButtonDown" />
+                        <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    </Style>
+                </ListBox.ItemContainerStyle>
+            </ListBox>
+        </Grid>
     </DockPanel>
 </UserControl>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
@@ -74,17 +74,19 @@
             ItemsSource="{Binding CoordinateAddInPoints}"
             SelectedIndex="{Binding ListBoxSelectedIndex}"
             SelectedItem="{Binding ListBoxSelectedItem}"
-            PreviewMouseDown="listBoxCoordinates_PreviewMouseDown" 
-            SelectionMode="Extended">
+            MouseLeftButtonDown="listBoxCoordinates_MouseLeftButtonDown"
+            SelectionMode="Extended" 
+            MouseRightButtonUp="listBoxCoordinates_MouseRightButtonUp">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Text}" />
+                        <TextBlock Text="{Binding Text}"/>
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
             <ListBox.ContextMenu>
-                <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
+                <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}"
+                             >
                     <MenuItem
                         Command="{Binding DataContext.DeletePointCommand}"
                         CommandParameter="{Binding Path=SelectedItems}"
@@ -115,7 +117,7 @@
                         Command="{Binding DataContext.ViewDetailCommand}"
                         CommandParameter="{Binding}"
                         Header="{x:Static prop:Resources.ViewDetails}"
-                        IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>
+                        IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>                    
                 </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.InputBindings>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
@@ -45,5 +45,11 @@ namespace CoordinateConversionLibrary.Views
         {
             this.listBoxCoordinates.UnselectAll();
         }
+
+        private void listBoxCoordinates_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            (sender as UIElement).Focus();
+            Keyboard.Focus(sender as UIElement);
+        }
     }
 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using CoordinateConversionLibrary.Helpers;
+using CoordinateConversionLibrary.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,7 +47,29 @@ namespace CoordinateConversionLibrary.Views
             this.listBoxCoordinates.UnselectAll();
         }
 
-        private void listBoxCoordinates_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        private void listBoxCoordinates_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            int index = -1;
+            for (int i = 0; i < listBoxCoordinates.Items.Count; i++)
+            {
+                var lbi = listBoxCoordinates.ItemContainerGenerator.ContainerFromIndex(i) as ListBoxItem;
+                if (lbi == null) continue;
+                if (IsMouseOverTarget(lbi, e.GetPosition((IInputElement)lbi)))
+                {
+                    index = i;
+                    break;
+                }
+            }
+            listBoxCoordinates.SelectedIndex = index;
+        }
+
+        private static bool IsMouseOverTarget(Visual target, Point point)
+        {
+            var bounds = VisualTreeHelper.GetDescendantBounds(target);
+            return bounds.Contains(point);
+        }
+
+        private void listBoxCoordinates_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             (sender as UIElement).Focus();
             Keyboard.Focus(sender as UIElement);

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCConvertTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCConvertTabView.xaml
@@ -18,9 +18,7 @@
             <UserControl Content="{Binding InputCCView}" />
         </GroupBox>
         <GroupBox Grid.Row="1" Header="{x:Static libprop:Resources.HeaderOutput}">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <UserControl Content="{Binding OutputCCView}" />
-            </ScrollViewer>
+            <UserControl Content="{Binding OutputCCView}" />
         </GroupBox>
         <GroupBox Grid.Row="2" Header="{x:Static libprop:Resources.HeaderList}">
             <UserControl Content="{Binding CollectTabView}" />

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
@@ -45,8 +45,8 @@
         x:Name="layoutRoot"
         MouseLeftButtonUp="OnMouseLeftButtonUp"
         MouseMove="OnMouseMove">
-        <StackPanel>            
-            <DataGrid
+        <StackPanel>
+            <DataGrid MaxHeight="220"
             x:Name="ocGrid"
             AutoGenerateColumns="False"
             CanUserAddRows="False"

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
@@ -45,7 +45,8 @@
         x:Name="layoutRoot"
         MouseLeftButtonUp="OnMouseLeftButtonUp"
         MouseMove="OnMouseMove">
-        <DataGrid
+        <StackPanel>            
+            <DataGrid
             x:Name="ocGrid"
             AutoGenerateColumns="False"
             CanUserAddRows="False"
@@ -57,60 +58,60 @@
             PreviewMouseLeftButtonDown="OnMouseLeftButtonDown"
             SelectionMode="Single"
             SizeChanged="ocGrid_SizeChanged">
-            <DataGrid.RowHeaderTemplate>
-                <DataTemplate>
-                    <Image
+                <DataGrid.RowHeaderTemplate>
+                    <DataTemplate>
+                        <Image
                         Width="10"
                         Height="10"
                         Cursor="Hand"
                         Source="/CoordinateConversionLibrary;component/Images/RowHandle.png" />
-                </DataTemplate>
-            </DataGrid.RowHeaderTemplate>
-            <DataGrid.RowStyle>
-                <Style TargetType="DataGridRow">
-                    <Setter Property="DetailsVisibility" Value="{Binding DVisibility}" />
-                    <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
-                </Style>
-            </DataGrid.RowStyle>
-            <DataGrid.Columns>
-                <DataGridTemplateColumn CanUserResize="False">
-                    <DataGridTemplateColumn.Header>
-                        <Button
+                    </DataTemplate>
+                </DataGrid.RowHeaderTemplate>
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="DetailsVisibility" Value="{Binding DVisibility}" />
+                        <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
+                    </Style>
+                </DataGrid.RowStyle>
+                <DataGrid.Columns>
+                    <DataGridTemplateColumn CanUserResize="False">
+                        <DataGridTemplateColumn.Header>
+                            <Button
                             Grid.Column="2"
                             Margin="0,0,0,0"
                             Command="{Binding DataContext.AddNewOCCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
                             Style="{StaticResource BorderlessButtonStyle}"
                             ToolTip="{x:Static prop:Resources.TooltipAdd}">
-                            <Image
+                                <Image
                                 Width="18"
                                 Height="18"
                                 Source="/CoordinateConversionLibrary;component/Images/hand.png" />
-                        </Button>
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <Button Command="{Binding DataContext.ExpandCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}" CommandParameter="{Binding Name}">
-                                <Button.Style>
-                                    <Style BasedOn="{StaticResource BorderlessButtonStyle}" TargetType="Button">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Collapsed">
-                                                <!--<Setter Property="Content" Value="▼" />-->
-                                                <Setter Property="Content" Value="{StaticResource expandImg}" />
-                                                <Setter Property="ToolTip" Value="Expand" />
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Visible">
-                                                <!--<Setter Property="Content" Value="▲" />-->
-                                                <Setter Property="Content" Value="{StaticResource collapseImg}" />
-                                                <Setter Property="ToolTip" Value="Collapse" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Button.Style>
                             </Button>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTextColumn
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Command="{Binding DataContext.ExpandCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}" CommandParameter="{Binding Name}">
+                                    <Button.Style>
+                                        <Style BasedOn="{StaticResource BorderlessButtonStyle}" TargetType="Button">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Collapsed">
+                                                    <!--<Setter Property="Content" Value="▼" />-->
+                                                    <Setter Property="Content" Value="{StaticResource expandImg}" />
+                                                    <Setter Property="ToolTip" Value="Expand" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Visible">
+                                                    <!--<Setter Property="Content" Value="▲" />-->
+                                                    <Setter Property="Content" Value="{StaticResource collapseImg}" />
+                                                    <Setter Property="ToolTip" Value="Collapse" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTextColumn
                     Width="Auto"
                     MinWidth="40"
                     Binding="{Binding Path=Name}"
@@ -118,137 +119,143 @@
                     Header="{x:Static prop:Resources.HeaderName}"
                     IsReadOnly="True"
                     SortDirection="Ascending">
-                    <DataGridTextColumn.ElementStyle>
-                        <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-                            <Setter Property="VerticalAlignment" Value="Center" />
-                        </Style>
-                    </DataGridTextColumn.ElementStyle>
-                </DataGridTextColumn>
-                <DataGridTemplateColumn Width="*" Header="{x:Static prop:Resources.HeaderCoordinate}">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <TextBox
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTemplateColumn Width="*" Header="{x:Static prop:Resources.HeaderCoordinate}">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBox
                                 BorderThickness="0"
                                 IsReadOnly="True"
                                 Text="{Binding OutputCoordinate}">
-                                <TextBox.Style>
-                                    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}" />
-                                </TextBox.Style>
-                            </TextBox>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTemplateColumn CanUserResize="False">
-                    <DataGridTemplateColumn.Header>
-                        <Button
+                                    <TextBox.Style>
+                                        <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}" />
+                                    </TextBox.Style>
+                                </TextBox>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn CanUserResize="False">
+                        <DataGridTemplateColumn.Header>
+                            <Button
                             Margin="0,0,0,0"
                             Command="{Binding DataContext.CopyAllCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
                             Style="{StaticResource BorderlessButtonStyle}"
                             ToolTip="{x:Static prop:Resources.TooltipCopyAll}">
-                            <Image
+                                <Image
                                 Width="18"
                                 Height="18"
                                 Source="/CoordinateConversionLibrary;component/Images/copyall.png" />
-                        </Button>
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <Button
+                            </Button>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button
                                 Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
                                 CommandParameter="{Binding OutputCoordinate}"
                                 Style="{StaticResource BorderlessButtonStyle}"
                                 ToolTip="{x:Static prop:Resources.TooltipCopy}">
-                                <Image
+                                    <Image
                                     Width="16"
                                     Height="16"
                                     Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
-                            </Button>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-            </DataGrid.Columns>
-            <DataGrid.RowDetailsTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Vertical">
-                        <ListBox HorizontalContentAlignment="Stretch" ItemsSource="{Binding Props}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" MinWidth="55" />
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+                <DataGrid.RowDetailsTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical">
+                            <ListBox HorizontalContentAlignment="Stretch" ItemsSource="{Binding Props}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" MinWidth="55" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock
                                             Margin="3,3,0,0"
                                             VerticalAlignment="Center"
                                             Text="{Binding Key, Mode=OneWay}">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}" />
-                                            </TextBlock.Style>
-                                        </TextBlock>
-                                        <TextBox
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}" />
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <TextBox
                                             Grid.Column="1"
                                             Margin="3,3,0,0"
                                             IsReadOnly="True"
                                             Text="{Binding Value, Mode=OneWay}" />
-                                        <Button
+                                            <Button
                                             Grid.Column="2"
                                             Margin="3,3,0,0"
                                             Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
                                             CommandParameter="{Binding Value}"
                                             Style="{StaticResource BorderedButtonStyle}"
                                             ToolTip="Copy">
-                                            <Image
+                                                <Image
                                                 Width="16"
                                                 Height="16"
                                                 Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
-                                        </Button>
-                                    </Grid>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </StackPanel>
-                </DataTemplate>
-            </DataGrid.RowDetailsTemplate>
-            <!--<DataGrid.ContextMenu>
+                                            </Button>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </DataTemplate>
+                </DataGrid.RowDetailsTemplate>
+                <!--<DataGrid.ContextMenu>
                 <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
                     <MenuItem Header="Configure" Command="{Binding DataContext.ConfigCommand}" CommandParameter="{Binding }" />
                     <MenuItem Header="Configure2" Command="{Binding DataContext.ConfigCommand}"
                               CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ContextMenu}, Path=PlacementTarget.CurrentItem.Name}" />
                 </ContextMenu>
             </DataGrid.ContextMenu>-->
-        </DataGrid>
-        <!--  Drag and Drop Popup  -->
-        <Popup
+            </DataGrid>
+            <!--  Drag and Drop Popup  -->
+            <Popup
             x:Name="popup1"
             AllowsTransparency="True"
             IsHitTestVisible="False"
             Placement="RelativePoint"
             PlacementTarget="{Binding ElementName=ocView}">
-            <Border
+                <Border
                 Background="White"
                 BorderBrush="LightSteelBlue"
                 BorderThickness="2"
                 Opacity="0.85">
-                <StackPanel Margin="4,3,8,3" Orientation="Horizontal">
-                    <Image
+                    <StackPanel Margin="4,3,8,3" Orientation="Horizontal">
+                        <Image
                         Width="16"
                         Height="16"
                         Margin="5,0,0,0"
                         Source="/CoordinateConversionLibrary;component/Images/hand.png" />
-                    <TextBlock
+                        <TextBlock
                         Margin="8,0,0,0"
                         VerticalAlignment="Center"
                         FontSize="14"
                         FontWeight="Bold"
                         Text="{Binding ElementName=ocView, Path=DraggedItem.Name}">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}" />
-                        </TextBlock.Style>
-                    </TextBlock>
-                </StackPanel>
-            </Border>
-        </Popup>
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}" />
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </Popup>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="btnReset" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Reset" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ResetButtonCommand}"/>
+                <Button x:Name="btnImport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Import" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ImportButtonCommand}"/>
+                <Button x:Name="btnExport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Export" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ExportButtonCommand}"/>
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/SelectCoordinateFieldsView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/SelectCoordinateFieldsView.xaml
@@ -11,8 +11,9 @@
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
+        Topmost="True"
         helpers:DialogCloser.DialogResult="{Binding DialogResult}"
-        mc:Ignorable="d" Height="169" Width="381">
+        mc:Ignorable="d" Height="300" Width="381">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -20,7 +21,7 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>
-    
+
     <StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,10,0,0">
             <TextBlock Margin="5,5,10,0" Text="{x:Static prop:Resources.LabelField1}" />
@@ -58,6 +59,22 @@
                       SelectedItem="{Binding SelectedField2}"
                       ItemContainerStyle="{StaticResource comboBoxItemStyle}">
             </ComboBox>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,10,0,0">
+            <TextBlock Text="Additional Fields" Margin="5" VerticalAlignment="Center"/>
+            <ListBox SelectedItem="{Binding Path=SelectedFieldItem,UpdateSourceTrigger=PropertyChanged}" 
+                    ItemsSource="{Binding FieldCollection, NotifyOnSourceUpdated=True}" Width="253" Height="100" Margin="20,0,0,0" SelectionMode="Multiple" >
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="{x:Type ListBoxItem}">
+                        <Setter Property="IsSelected" Value="{Binding Mode=TwoWay, Path=IsSelected}"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+            </ListBox>
         </StackPanel>
         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,10,0,0">
             <Button Width="75"

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Models/AddInPoint.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Models/AddInPoint.cs
@@ -47,11 +47,11 @@ namespace ProAppCoordConversionModule.Models
         }
         public string Text
         {
-            get 
+            get
             {
                 try
                 {
-                    return MapPointHelper.GetMapPointAsDisplayString(Point); 
+                    return MapPointHelper.GetMapPointAsDisplayString(Point);
                 }
                 catch
                 {
@@ -89,6 +89,13 @@ namespace ProAppCoordConversionModule.Models
                 isSelected = value;
                 RaisePropertyChanged(() => IsSelected);
             }
+        }
+
+        private Dictionary<string, Tuple<object, bool>> fieldsDictionary;
+        public Dictionary<string, Tuple<object, bool>> FieldsDictionary
+        {
+            get { return fieldsDictionary; }
+            set { fieldsDictionary = value; }
         }
     }
 }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ProAppCoordConversionModule.csproj
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ProAppCoordConversionModule.csproj
@@ -155,6 +155,9 @@
     <Compile Include="ViewModels\ProOutputCoordinateViewModel.cs" />
     <Compile Include="ViewModels\ProSaveAsFormatViewModel.cs" />
     <Compile Include="ViewModels\ProTabBaseViewModel.cs" />
+    <Compile Include="Views\ProAdditionalFieldsView.xaml.cs">
+      <DependentUpon>ProAdditionalFieldsView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\ProAmbiguousCoordsView.xaml.cs">
       <DependentUpon>ProAmbiguousCoordsView.xaml</DependentUpon>
     </Compile>
@@ -190,6 +193,10 @@
     <Page Include="UI\FlashEmbeddedControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ProAdditionalFieldsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\ProAmbiguousCoordsView.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Esri 
+// Copyright 2016 Esri 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,6 +67,8 @@ namespace ProAppCoordConversionModule.ViewModels
 
         private async void OnImportCoordinates(object obj)
         {
+            pDialog.Show();
+            IsToolActive = false;
             if (obj == null)
                 return;
             var input = obj as List<Dictionary<string, Tuple<object, bool>>>;
@@ -103,6 +105,7 @@ namespace ProAppCoordConversionModule.ViewModels
 
                 InputCoordinate = "";
             }
+            pDialog.Hide();
         }
 
         private void ClearListBoxSelection()

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -70,7 +70,7 @@ namespace ProAppCoordConversionModule.ViewModels
             Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.CollectListHasItems, CoordinateAddInPoints.Any());
         }
 
-        private void OnImportCoordinates(object obj)
+        private async void OnImportCoordinates(object obj)
         {
             var coordinates = obj as List<string>;
             if (coordinates == null)
@@ -80,7 +80,7 @@ namespace ProAppCoordConversionModule.ViewModels
 
             foreach (var coordinate in coordinates)
             {
-                this.ProcessInput(coordinate);
+                await ProcessInputAsync(coordinate);
                 InputCoordinate = coordinate;
                 if (!HasInputError)
                     OnNewMapPoint(proCoordGetter.Point);

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -348,8 +348,6 @@ namespace ProAppCoordConversionModule.ViewModels
 
             //Add point to the top of the list
             CoordinateAddInPoints.Insert(0, addInPoint);
-            CoordinateAddInPoints.ToList().ForEach(x => x.IsSelected = false);
-            CoordinateAddInPoints.ElementAt(0).IsSelected = true;
         }
 
         private void RemoveGraphics(List<string> guidList)

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProCollectTabViewModel.cs
@@ -12,27 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArcGIS.Core.Geometry;
+using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Desktop.Mapping;
+using CoordinateConversionLibrary;
+using CoordinateConversionLibrary.Helpers;
+using CoordinateConversionLibrary.Models;
+using Jitbit.Utils;
+using ProAppCoordConversionModule.Models;
+using ProAppCoordConversionModule.Views;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using ArcGIS.Core.CIM;
-using ArcGIS.Core.Geometry;
-using ArcGIS.Desktop.Framework.Threading.Tasks;
-using ArcGIS.Desktop.Mapping;
-using CoordinateConversionLibrary.Helpers;
-using ProAppCoordConversionModule.Models;
-using ProAppCoordConversionModule.Views;
-using ProAppCoordConversionModule.ViewModels;
-using CoordinateConversionLibrary;
-using System;
 using System.Text;
-using Jitbit.Utils;
-using System.Windows;
-using System.IO;
-using CoordinateConversionLibrary.ViewModels;
-using CoordinateConversionLibrary.Models;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace ProAppCoordConversionModule.ViewModels
 {
@@ -40,8 +36,8 @@ namespace ProAppCoordConversionModule.ViewModels
     {
         public ProCollectTabViewModel()
         {
-            ListBoxItemAddInPoint = null; 
-            
+            ListBoxItemAddInPoint = null;
+
             CoordinateAddInPoints = new ObservableCollection<AddInPoint>();
 
             DeletePointCommand = new RelayCommand(OnDeletePointCommand);
@@ -72,20 +68,43 @@ namespace ProAppCoordConversionModule.ViewModels
 
         private async void OnImportCoordinates(object obj)
         {
-            var coordinates = obj as List<string>;
-            if (coordinates == null)
+            if (obj == null)
                 return;
+            var input = obj as List<Dictionary<string, Tuple<object, bool>>>;
+            if (input != null)
+                foreach (var item in input)
+                {
+                    var coordinate = item.Where(x => x.Key == OutputFieldName).Select(x => Convert.ToString(x.Value.Item1)).FirstOrDefault();
+                    if (coordinate == "" || item.Where(x => x.Key == PointFieldName).Any())
+                        continue;
+                    //this.ProcessInput(coordinate);
+                    await this.ProcessInputAsync(coordinate);
+                    InputCoordinate = coordinate;
 
-            this.ClearListBoxSelection();
-
-            foreach (var coordinate in coordinates)
+                    if (!HasInputError)
+                    {
+                        if (item.ContainsKey(PointFieldName))
+                            continue;
+                        item.Add(PointFieldName, Tuple.Create((object)proCoordGetter.Point, false));
+                        OnNewMapPoint(item);
+                    }
+                }
+            else
             {
-                await ProcessInputAsync(coordinate);
-                InputCoordinate = coordinate;
-                if (!HasInputError)
-                    OnNewMapPoint(proCoordGetter.Point);
+                List<string> coordinates = obj as List<string>;
+                if (coordinates == null)
+                    return;
+                this.ClearListBoxSelection();
+                foreach (var coordinate in coordinates)
+                {
+                    await ProcessInputAsync(coordinate);
+                    InputCoordinate = coordinate;
+                    if (!HasInputError)
+                        OnNewMapPoint(proCoordGetter.Point);
+                }
+
+                InputCoordinate = "";
             }
-            InputCoordinate = "";
         }
 
         private void ClearListBoxSelection()
@@ -109,7 +128,7 @@ namespace ProAppCoordConversionModule.ViewModels
             }
         }
 
-        public AddInPoint ListBoxItemAddInPoint { get; set; }        
+        public AddInPoint ListBoxItemAddInPoint { get; set; }
         private object _ListBoxSelectedItem = null;
         public object ListBoxSelectedItem
         {
@@ -185,7 +204,7 @@ namespace ProAppCoordConversionModule.ViewModels
         }
 
         // copy parameter to clipboard
-        private void OnCopyCommand(object obj)
+        public override void OnCopyCommand(object obj)
         {
             var items = obj as IList;
             if (items == null)
@@ -214,12 +233,9 @@ namespace ProAppCoordConversionModule.ViewModels
             var saveAsDialog = new ProSaveAsFormatView();
             var vm = new ProSaveAsFormatViewModel();
             saveAsDialog.DataContext = vm;
-
-
             if (saveAsDialog.ShowDialog() == true)
             {
                 var fcUtils = new FeatureClassUtils();
-
                 string path = fcUtils.PromptUserWithSaveDialog(vm.FeatureIsChecked, vm.ShapeIsChecked, vm.KmlIsChecked, vm.CSVIsChecked);
                 if (path != null)
                 {
@@ -227,9 +243,9 @@ namespace ProAppCoordConversionModule.ViewModels
                     {
                         string folderName = System.IO.Path.GetDirectoryName(path);
                         var mapPointList = CoordinateAddInPoints.Select(i => i.Point).ToList();
-                        var ccMapPointList = GetMapPointExportFormat(CoordinateAddInPoints);
                         if (vm.FeatureIsChecked)
                         {
+                            var ccMapPointList = GetMapPointExportFormat(CoordinateAddInPoints);
                             await fcUtils.CreateFCOutput(path,
                                                          SaveAsType.FileGDB,
                                                          ccMapPointList,
@@ -239,26 +255,31 @@ namespace ProAppCoordConversionModule.ViewModels
                         }
                         else if (vm.ShapeIsChecked || vm.KmlIsChecked)
                         {
+                            var ccMapPointList = GetMapPointExportFormat(CoordinateAddInPoints);
                             await fcUtils.CreateFCOutput(path, SaveAsType.Shapefile, ccMapPointList, MapView.Active.Map.SpatialReference, MapView.Active, CoordinateConversionLibrary.GeomType.Point, vm.KmlIsChecked);
                         }
                         else if (vm.CSVIsChecked)
                         {
                             var aiPoints = CoordinateAddInPoints.ToList();
-
                             if (!aiPoints.Any())
                                 return;
-
                             var csvExport = new CsvExport();
+                            var displayAmb = CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg;
                             foreach (var point in aiPoints)
                             {
                                 var results = GetOutputFormats(point);
                                 csvExport.AddRow();
-                                foreach (KeyValuePair<string, string> format in results)
+                                foreach (var item in results)
+                                    csvExport[item.Key] = item.Value;
+                                if (point.FieldsDictionary != null)
                                 {
-                                    csvExport[format.Key] = format.Value;
+                                    foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
+                                        if (item.Key != PointFieldName && item.Key != OutputFieldName)
+                                            csvExport[item.Key] = item.Value;
                                 }
-
+                                CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
                             }
+                            CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = displayAmb;
                             csvExport.ExportToFile(path);
 
                             System.Windows.Forms.MessageBox.Show(CoordinateConversionLibrary.Properties.Resources.CSVExportSuccessfulMessage + path,
@@ -276,13 +297,19 @@ namespace ProAppCoordConversionModule.ViewModels
         private List<CCProGraphic> GetMapPointExportFormat(ObservableCollection<AddInPoint> mapPointList)
         {
             List<CCProGraphic> results = new List<CCProGraphic>();
+            var dictionary = new Dictionary<string, object>();
             foreach (var point in mapPointList)
             {
                 var attributes = GetOutputFormats(point);
+                if (point.FieldsDictionary != null)
+                {
+                    foreach (KeyValuePair<string, Tuple<object, bool>> item in point.FieldsDictionary)
+                        if (item.Key != PointFieldName && item.Key != OutputFieldName)
+                            attributes[item.Key] = Convert.ToString(item.Value);
+                }
                 CCProGraphic ccMapPoint = new CCProGraphic() { Attributes = attributes, MapPoint = point.Point };
                 results.Add(ccMapPoint);
             }
-
             return results;
         }
 
@@ -307,12 +334,12 @@ namespace ProAppCoordConversionModule.ViewModels
                 // copy to clipboard
                 System.Windows.Clipboard.SetText(sb.ToString());
             }
-        }        
+        }
 
-        private async void AddCollectionPoint(MapPoint point)
+        private async void AddCollectionPoint(MapPoint point, Dictionary<string, Tuple<object, bool>> fieldsDictionary = null)
         {
             var guid = await AddGraphicToMap(point, ColorFactory.Instance.RedRGB, true, 7);
-            var addInPoint = new AddInPoint() { Point = point, GUID = guid };
+            var addInPoint = new AddInPoint() { Point = point, GUID = guid, FieldsDictionary = fieldsDictionary };
 
             //Add point to the top of the list
             CoordinateAddInPoints.Insert(0, addInPoint);
@@ -353,7 +380,7 @@ namespace ProAppCoordConversionModule.ViewModels
             RaisePropertyChanged(() => HasListBoxRightClickSelectedItem);
         }
 
-        private void OnPasteCommand(object obj)
+        public override void OnPasteCommand(object obj)
         {
             var input = Clipboard.GetText().Trim();
             string[] lines = input.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
@@ -394,7 +421,17 @@ namespace ProAppCoordConversionModule.ViewModels
             if (!base.OnNewMapPoint(obj))
                 return false;
 
-            AddCollectionPoint(obj as MapPoint);
+            var input = obj as Dictionary<string, Tuple<object, bool>>;
+            if (input != null)
+            {
+                var point = input.Where(x => x.Key == PointFieldName).Select(x => x.Value.Item1).FirstOrDefault();
+                AddCollectionPoint(point as MapPoint, input);
+            }
+            else
+            {
+                var point = obj as MapPoint;
+                AddCollectionPoint(point, input);
+            }
 
             return true;
         }
@@ -411,7 +448,7 @@ namespace ProAppCoordConversionModule.ViewModels
         }
 
         public override async void OnMapPointSelection(object obj)
-        {         
+        {
             var mp = obj as MapPoint;
             var poly = GeometryEngine.Instance.Buffer(mp, 20000);
             AddInPoint closestPoint = null;
@@ -436,7 +473,7 @@ namespace ProAppCoordConversionModule.ViewModels
                 closestPoint.IsSelected = true;
                 ListBoxSelectedItem = closestPoint;
             }
-            RaisePropertyChanged(() => ListBoxSelectedItem);           
+            RaisePropertyChanged(() => ListBoxSelectedItem);
         }
 
         #endregion overrides

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
@@ -1,16 +1,24 @@
 ﻿using CoordinateConversionLibrary.Models;
 using CoordinateConversionLibrary.ViewModels;
 using CoordinateConversionLibrary.Views;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace ProAppCoordConversionModule.ViewModels
 {
     public class ProOutputCoordinateViewModel : OutputCoordinateViewModel
     {
+        string headers = string.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3},{4},{5},{6}"
+                        , "CType", "DVisibility", "Format", "Name", "OutputCoordinate", "SRFactoryCode", "SRName");
+
         #region overrides
 
         public override void OnAddNewOutputCoordinate(object obj)
@@ -87,6 +95,100 @@ namespace ProAppCoordConversionModule.ViewModels
             CoordinateConversionLibraryConfig.AddInConfig.SaveConfiguration();
         }
 
+        public override void OnImportButtonCommand(object obj)
+        {
+            try
+            {
+                var openDialog = new OpenFileDialog();
+                openDialog.Title = "Open File";
+                openDialog.CheckFileExists = true;
+                openDialog.CheckPathExists = true;
+                openDialog.Filter = "csv files|*.csv";
+                if (openDialog.ShowDialog()==true)
+                {
+                    var filePath = openDialog.FileName;
+                    var s = File.ReadAllText(filePath);
+                    var dt = new DataTable();
+                    string[] tableData = s.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+                    var col = from cl in tableData[0].Split(",".ToCharArray())
+                              select new DataColumn(cl);
+                    dt.Columns.AddRange(col.ToArray());
+                    (from st in tableData.Skip(1)
+                     select dt.Rows.Add(st.Split(",".ToCharArray()))).ToList();
+                    var temp = dt;
+                    foreach (DataRow item in dt.Rows)
+                    {
+                        CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Add(
+                        new OutputCoordinateModel()
+                        {
+                            CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"])),
+                            DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"])),
+                            Format = Convert.ToString(item["Format"]),
+                            Name = Convert.ToString(item["Name"]),
+                            OutputCoordinate = Convert.ToString(item["OutputCoordinate"]),
+                            SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]),
+                            SRName = Convert.ToString(item["SRName"])
+                        });
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Something went wrong.");
+            }
+        }
+
+        public override void OnExportButtonCommand(object obj)
+        {
+            try
+            {
+                if (CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Count==0)
+                {
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("No data available");
+                    return;
+                }
+                var saveDialog = new SaveFileDialog();
+                saveDialog.Title = "Save File";
+                saveDialog.Filter = "csv files|*.csv";
+                saveDialog.ShowDialog();
+                var filePath = saveDialog.FileName;
+                using (var file = File.CreateText(filePath))
+                {
+                    var list = CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList
+                        .Select(x => new
+                        {
+                            CType = x.CType,
+                            DVisibility = x.DVisibility,
+                            Format = x.Format,
+                            Name = x.Name,
+                            OutputCoordinate = x.OutputCoordinate,
+                            SRFactoryCode = x.SRFactoryCode,
+                            SRName = x.SRName
+                        });
+                    file.Write(headers);
+                    file.WriteLine();
+                    foreach (var arr in list)
+                    {
+                        if (arr == null) continue;
+                        var str = string.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3},{4},{5},{6}"
+                            , arr.CType, arr.DVisibility, arr.Format, arr.Name, arr.OutputCoordinate, arr.SRFactoryCode, arr.SRName);
+                        file.Write(str);
+                        file.WriteLine();
+                    }
+                }
+                ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("File Exported to " + filePath);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public override void OnResetButtonCommand(object obj)
+        {
+            CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList = new System.Collections.ObjectModel.ObservableCollection<OutputCoordinateModel>();
+            CoordinateConversionLibraryConfig.AddInConfig.SaveConfiguration();
+            RaisePropertyChanged(() => CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList);
+        }
         #endregion
     }
 }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
@@ -104,7 +104,7 @@ namespace ProAppCoordConversionModule.ViewModels
                 openDialog.CheckFileExists = true;
                 openDialog.CheckPathExists = true;
                 openDialog.Filter = "csv files|*.csv";
-                if (openDialog.ShowDialog()==true)
+                if (openDialog.ShowDialog() == true)
                 {
                     var filePath = openDialog.FileName;
                     var s = File.ReadAllText(filePath);
@@ -118,17 +118,35 @@ namespace ProAppCoordConversionModule.ViewModels
                     var temp = dt;
                     foreach (DataRow item in dt.Rows)
                     {
-                        CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Add(
-                        new OutputCoordinateModel()
+                        string itemName = Convert.ToString(item["Name"]);
+                        var coordFormats = CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Where(x => x.Name == itemName).ToList();
+                        if (coordFormats.Count > 0)
                         {
-                            CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"])),
-                            DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"])),
-                            Format = Convert.ToString(item["Format"]),
-                            Name = Convert.ToString(item["Name"]),
-                            OutputCoordinate = Convert.ToString(item["OutputCoordinate"]),
-                            SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]),
-                            SRName = Convert.ToString(item["SRName"])
-                        });
+                            CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Where(x => x.Name == itemName).Select(x =>
+                            {
+                                x.CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"]));
+                                x.DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"]));
+                                x.Format = Convert.ToString(item["Format"]);
+                                x.OutputCoordinate = Convert.ToString(item["OutputCoordinate"]);
+                                x.SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]);
+                                x.SRName = Convert.ToString(item["SRName"]);
+                                return x;
+                            }).ToList();
+                        }
+                        else
+                        {
+                            CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Add(
+                            new OutputCoordinateModel()
+                            {
+                                CType = (CoordinateType)Enum.Parse(typeof(CoordinateType), Convert.ToString(item["Ctype"])),
+                                DVisibility = (Visibility)Enum.Parse(typeof(Visibility), Convert.ToString(item["DVisibility"])),
+                                Format = Convert.ToString(item["Format"]),
+                                Name = itemName,
+                                OutputCoordinate = Convert.ToString(item["OutputCoordinate"]),
+                                SRFactoryCode = Convert.ToInt32(item["SRFactoryCode"]),
+                                SRName = Convert.ToString(item["SRName"])
+                            });
+                        }
                     }
                 }
             }
@@ -142,7 +160,7 @@ namespace ProAppCoordConversionModule.ViewModels
         {
             try
             {
-                if (CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Count==0)
+                if (CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Count == 0)
                 {
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("No data available");
                     return;

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Esri 
+// Copyright 2016 Esri 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ namespace ProAppCoordConversionModule.ViewModels
             ListDictionary = new List<Dictionary<string, Tuple<object, bool>>>();
             Mediator.Register(CoordinateConversionLibrary.Constants.RequestCoordinateBroadcast, OnBCNeeded);
             Mediator.Register("FLASH_COMPLETED", OnFlashCompleted);
-
+            pDialog = new ProgressDialog("Processing...Please wait...");
             Mediator.NotifyColleagues(CoordinateConversionLibrary.Constants.SetCoordinateGetter, proCoordGetter);
 
             ArcGIS.Desktop.Framework.Events.ActiveToolChangedEvent.Subscribe(OnActiveToolChanged);
@@ -63,7 +63,8 @@ namespace ProAppCoordConversionModule.ViewModels
         public CoordinateConversionLibrary.Helpers.RelayCommand ActivatePointToolCommand { get; set; }
         public CoordinateConversionLibrary.Helpers.RelayCommand FlashPointCommand { get; set; }
         public CoordinateConversionLibrary.Helpers.RelayCommand ViewDetailCommand { get; set; }
-
+        
+        public static ProgressDialog pDialog { get; set; }
         public static ProCoordinateGet proCoordGetter = new ProCoordinateGet();
         public String PreviousTool { get; set; }
         public static ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProTabBaseViewModel.cs
@@ -51,6 +51,7 @@ namespace ProAppCoordConversionModule.ViewModels
             FlashPointCommand = new CoordinateConversionLibrary.Helpers.RelayCommand(OnFlashPointCommandAsync);
             ViewDetailCommand = new CoordinateConversionLibrary.Helpers.RelayCommand(OnViewDetailCommand);
             FieldsCollection = new ObservableCollection<FieldsCollection>();
+            ViewDetailsTitle = string.Empty;
             ListDictionary = new List<Dictionary<string, Tuple<object, bool>>>();
             Mediator.Register(CoordinateConversionLibrary.Constants.RequestCoordinateBroadcast, OnBCNeeded);
             Mediator.Register("FLASH_COMPLETED", OnFlashCompleted);
@@ -63,12 +64,13 @@ namespace ProAppCoordConversionModule.ViewModels
         public CoordinateConversionLibrary.Helpers.RelayCommand ActivatePointToolCommand { get; set; }
         public CoordinateConversionLibrary.Helpers.RelayCommand FlashPointCommand { get; set; }
         public CoordinateConversionLibrary.Helpers.RelayCommand ViewDetailCommand { get; set; }
-        
+
         public static ProgressDialog pDialog { get; set; }
         public static ProCoordinateGet proCoordGetter = new ProCoordinateGet();
         public String PreviousTool { get; set; }
         public static ObservableCollection<AddInPoint> CoordinateAddInPoints { get; set; }
         public ObservableCollection<FieldsCollection> FieldsCollection { get; set; }
+        public string ViewDetailsTitle { get; set; }
         public static Dictionary<string, ObservableCollection<Symbol>> AllSymbolCollection { get; set; }
 
         public static Symbol SelectedSymbolObject { get; set; }
@@ -737,11 +739,11 @@ namespace ProAppCoordConversionModule.ViewModels
                     FieldsCollection.Add(new FieldsCollection() { FieldName = item.Key, FieldValue = Convert.ToString(item.Value.Item1) });
             }
             var valOutput = dictionary.Where(x => x.Key == PointFieldName).Select(x => x.Value.Item1).FirstOrDefault();
-            FieldsCollection.Add(new FieldsCollection() { FieldName = OutputFieldName, FieldValue = MapPointHelper.GetMapPointAsDisplayString(valOutput as MapPoint) });
-            var diag = new ProAdditionalFieldsView();
-            diag.DataContext = this;
-            diag.ShowDialog();
-        }        
+            ViewDetailsTitle = MapPointHelper.GetMapPointAsDisplayString(valOutput as MapPoint);
+            var dialog = new ProAdditionalFieldsView();
+            dialog.DataContext = this;
+            dialog.ShowDialog();
+        }
 
         internal async void UpdateHighlightedGraphics(bool reset, bool isUpdateAll = false)
         {

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml
@@ -1,0 +1,140 @@
+﻿<controls:ProWindow x:Class="ProAppCoordConversionModule.Views.ProAdditionalFieldsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:controls="clr-namespace:ArcGIS.Desktop.Framework.Controls;assembly=ArcGIS.Desktop.Framework"
+            xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"                      
+            xmlns:local="clr-namespace:CoordinateConversionLibrary;assembly=CoordinateConversionLibrary"
+            xmlns:prop="clr-namespace:CoordinateConversionLibrary.Properties;assembly=CoordinateConversionLibrary"
+            xmlns:viewModels="clr-namespace:CoordinateConversionLibrary.ViewModels;assembly=CoordinateConversionLibrary"
+            xmlns:Behaviors="clr-namespace:ArcGIS.Desktop.Internal.Framework.Behaviors;assembly=ArcGIS.Desktop.Framework"
+             xmlns:helpers="clr-namespace:CoordinateConversionLibrary.Helpers;assembly=CoordinateConversionLibrary"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             mc:Ignorable="d" 
+             Title="Additional Fields" 
+             WindowStartupLocation="CenterScreen"
+             SizeToContent="WidthAndHeight"          
+             helpers:DialogCloser.DialogResult="{Binding DialogResult}"
+             ResizeMode="NoResize" WindowStyle="ThreeDBorderWindow" Cursor="Arrow" Topmost="True"
+             d:Height="210" d:Width="280">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
+                <ResourceDictionary Source="/CoordinateConversionLibrary;component/MAResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <viewModels:EditOutputCoordinateViewModel x:Key="viewModelEdit" />
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="Transparent">
+        <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding FieldsCollection}" HorizontalAlignment="Left"
+            CanUserAddRows="False"
+            CanUserDeleteRows="False"
+            CanUserReorderColumns="False"
+            CanUserResizeRows="False"
+            CanUserSortColumns="False"
+                  HeadersVisibility="Column"
+                  RowHeight="25"
+                  Name="dgTripwire" VerticalAlignment="Top"
+                  FontFamily="{DynamicResource DefaultFontFamily}"
+			    Style="{DynamicResource Esri_DataGrid}" ColumnHeaderStyle="{DynamicResource DataGridColumnHeaderStyleCustom}">
+            <DataGrid.Resources>
+                <Style x:Key="DataGridColumnHeaderStyleCustom" TargetType="{x:Type DataGridColumnHeader}">
+                    <Setter Property="Foreground" Value="{DynamicResource Esri_Gray160}"/>
+                    <!--<Setter Property="Background" Value="{DynamicResource Esri_Gray120}"/>-->
+                    <Setter Property="BorderBrush" Value="{DynamicResource Esri_Gray120}"/>
+                    <Setter Property="Margin" Value="0"/>
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                    <Setter Property="VerticalContentAlignment" Value="Center"/>
+                    <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                    <Setter Property="Padding" Value="6"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
+                                <Grid x:Name="HeaderGrid" Focusable="True">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Border x:Name="BackgroundBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,1" Grid.ColumnSpan="3" Height="28"/>
+                                    <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Grid.Column="0" ContentStringFormat="{TemplateBinding ContentStringFormat}" Margin="6,3" VerticalAlignment="Center"/>
+                                    <Path x:Name="SortArrow" Grid.Column="1" Data="F1M0,0L0,0.001 3.5,3.5 7,0 0,0z" Fill="#FF6C6D70" HorizontalAlignment="Right" Height="3.5" Margin="0" RenderTransformOrigin="0.5,0.4" Stretch="Fill" Visibility="Collapsed" VerticalAlignment="Center" Width="7"/>
+                                    <Thumb x:Name="PART_LeftHeaderGripper" Cursor="SizeWE" Grid.Column="0" HorizontalAlignment="Left">
+                                        <Thumb.Style>
+                                            <Style TargetType="{x:Type Thumb}">
+                                                <Setter Property="Width" Value="6"/>
+                                                <Setter Property="Template">
+                                                    <Setter.Value>
+                                                        <ControlTemplate TargetType="{x:Type Thumb}">
+                                                            <Border Background="Transparent">
+                                                                <Border Background="{DynamicResource Esri_Gray125}" Width="0"/>
+                                                            </Border>
+                                                        </ControlTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </Thumb.Style>
+                                    </Thumb>
+                                    <Thumb x:Name="PART_RightHeaderGripper" Cursor="SizeWE" Grid.Column="2" HorizontalAlignment="Right">
+                                        <Thumb.Style>
+                                            <Style TargetType="{x:Type Thumb}">
+                                                <Setter Property="Width" Value="6"/>
+                                                <Setter Property="Template">
+                                                    <Setter.Value>
+                                                        <ControlTemplate TargetType="{x:Type Thumb}">
+                                                            <Border Background="Transparent">
+                                                                <Border Background="{DynamicResource Esri_Gray125}" Width="0"/>
+                                                            </Border>
+                                                        </ControlTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </Thumb.Style>
+                                    </Thumb>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" TargetName="HeaderGrid" Value="{DynamicResource Esri_Blue2}"/>
+                                    </Trigger>
+                                    <Trigger Property="IsPressed" Value="True">
+                                        <Setter Property="Background" TargetName="HeaderGrid" Value="{DynamicResource Esri_Blue3}"/>
+                                    </Trigger>
+                                    <Trigger Property="Behaviors:DataGridBehavior.IsSelectedHeader" Value="True">
+                                        <Setter Property="Background" TargetName="HeaderGrid" Value="{DynamicResource Esri_Blue6}"/>
+                                    </Trigger>
+                                    <Trigger Property="SortDirection" Value="Ascending">
+                                        <Setter Property="Visibility" TargetName="SortArrow" Value="Visible"/>
+                                        <Setter Property="RenderTransform" TargetName="SortArrow">
+                                            <Setter.Value>
+                                                <RotateTransform Angle="180"/>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Trigger>
+                                    <Trigger Property="SortDirection" Value="Descending">
+                                        <Setter Property="Visibility" TargetName="SortArrow" Value="Visible"/>
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </DataGrid.Resources>
+            <DataGrid.RowStyle>
+                <Style TargetType="{x:Type DataGridRow}">
+                    <Style.Triggers>
+                        <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                            <Setter Property="Background" Value="{DynamicResource Esri_ControlBackgroundBrush}"></Setter>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
+            <!--Visibility="{Binding SchedulerData.DataGridVisible,Mode=TwoWay,Converter={StaticResource visibilityConverter}}"-->
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Field Name" Binding="{Binding Path=FieldName}" FontWeight="Bold"/>
+                <DataGridTextColumn Header="Field Value" Binding="{Binding Path=FieldValue}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</controls:ProWindow>

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml
@@ -12,7 +12,7 @@
              xmlns:helpers="clr-namespace:CoordinateConversionLibrary.Helpers;assembly=CoordinateConversionLibrary"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
-             Title="Additional Fields" 
+             Title="{Binding ViewDetailsTitle}" 
              WindowStartupLocation="CenterScreen"
              SizeToContent="WidthAndHeight"          
              helpers:DialogCloser.DialogResult="{Binding DialogResult}"

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProAdditionalFieldsView.xaml.cs
@@ -1,0 +1,29 @@
+﻿using CoordinateConversionLibrary.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace ProAppCoordConversionModule.Views
+{
+    /// <summary>
+    /// Interaction logic for ProAmbiguousCoordsView.xaml
+    /// </summary>
+    public partial class ProAdditionalFieldsView : ArcGIS.Desktop.Framework.Controls.ProWindow
+    {
+        public ProAdditionalFieldsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
@@ -129,270 +129,281 @@
 		x:Name="layoutRoot"
 		MouseLeftButtonUp="OnMouseLeftButtonUp"
 		MouseMove="OnMouseMove">
-        <DataGrid
-			x:Name="ocGrid"
-			AutoGenerateColumns="False"
-			CanUserAddRows="False"
-			CanUserDeleteRows="False"
-			CanUserReorderColumns="False"
-			CanUserResizeRows="False"
-			CanUserSortColumns="False"
-			ItemsSource="{Binding OutputCoordinateList}"
-			PreviewMouseLeftButtonDown="OnMouseLeftButtonDown"
-			SelectionMode="Single"
-			SizeChanged="ocGrid_SizeChanged"
-            FontSize="12"
-            FontFamily="{DynamicResource DefaultFontFamily}"
-			Style="{DynamicResource Esri_DataGrid}" ColumnHeaderStyle="{DynamicResource DataGridColumnHeaderStyleCustom}" RowHeaderStyle="{DynamicResource DataGridRowHeaderStyleCustom}">
-            <DataGrid.Resources>
-                <Style x:Key="DataGridRowHeaderStyleCustom" TargetType="{x:Type DataGridRowHeader}">
-                    <Setter Property="MinWidth" Value="20"/>
-                    <Setter Property="MinHeight" Value="20"/>
-                    <Setter Property="Cursor" Value="Hand"/>
-                    <Setter Property="Foreground" Value="{DynamicResource Esri_TextStyleDefaultBrush}"/>
-                    <Setter Property="Background" Value="{DynamicResource Esri_ControlBackgroundBrush}"/>
-                    <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderBrush}"/>
-                    <Setter Property="BorderThickness" Value="1,1,1,1"/>
-                    <!--<Setter Property="Background">
-                        <Setter.Value>
-                            <ImageBrush/>
-                        </Setter.Value>
-                    </Setter>-->
-                    <Style.Triggers>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsRowSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" Value="{DynamicResource Esri_Blue2}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsRowSelected" Value="True"/>
-                                <Condition Property="IsMouseOver" Value="False"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" Value="{DynamicResource Esri_Blue6}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsRowSelected" Value="True"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" Value="{DynamicResource Esri_Blue3}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsRowSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="False"/>
-                                <Condition Property="Behaviors:DataGridBehavior.IsSelectedHeader" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" Value="{DynamicResource Esri_Blue6}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsRowSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                                <Condition Property="Behaviors:DataGridBehavior.IsSelectedHeader" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" Value="{DynamicResource Esri_Blue3}"/>
-                        </MultiTrigger>
-                    </Style.Triggers>
-                </Style>
-            </DataGrid.Resources>
-            <DataGrid.RowHeaderTemplate>
-                <DataTemplate>
-                    <Image
-						Width="10"
-						Height="10"
-						Cursor="Hand"
-						Source="/CoordinateConversionLibrary;component/Images/RowHandle.png" />
-                </DataTemplate>
-            </DataGrid.RowHeaderTemplate>
-            <DataGrid.RowStyle>
-                <Style TargetType="{x:Type DataGridRow}">
-                    <Setter Property="DetailsVisibility" Value="{Binding DVisibility}" />
-                    <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
-                    <Style.Triggers>
-                        <Trigger Property="ItemsControl.AlternationIndex" Value="1">
-                            <Setter Property="Background" Value="{DynamicResource Esri_ControlBackgroundBrush}"></Setter>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </DataGrid.RowStyle>
-            <DataGrid.Columns>
-                <DataGridTemplateColumn CanUserResize="False">
-                    <DataGridTemplateColumn.Header>
-                        <Button
-							Grid.Column="2"
-							Margin="0,0,0,0"
-							Command="{Binding DataContext.AddNewOCCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
-							ToolTip="{x:Static prop:Resources.TooltipAdd}"
-							Style="{StaticResource ImageButtonStyle}">
-                            <Image
-								Height="18"
-								Width="18"
-								Source="/CoordinateConversionLibrary;component/Images/hand.png" />
-                        </Button>
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <Button Command="{Binding DataContext.ExpandCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}" CommandParameter="{Binding Name}">
-                                <Button.Style>
-                                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ImageButtonStyle}">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Collapsed">
-                                                <!--<Setter Property="Content" Value="?" />-->
-                                                <Setter Property="Content" Value="{StaticResource expandImg}" />
-                                                <Setter Property="ToolTip" Value="Expand" />
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Visible">
-                                                <!--<Setter Property="Content" Value="?" />-->
-                                                <Setter Property="Content" Value="{StaticResource collapseImg}" />
-                                                <Setter Property="ToolTip" Value="Collapse" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Button.Style>
-                            </Button>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTextColumn
-					Width="Auto"
-					MinWidth="40"
-					Binding="{Binding Name}"
-                    FontSize="12"
-                    FontFamily="{DynamicResource DefaultFontFamily}"
-					FontWeight="Bold"
-					Header="{x:Static prop:Resources.HeaderName}"
-					IsReadOnly="True"
-					SortDirection="Ascending">
-                    <DataGridTextColumn.ElementStyle>
-                        <Style TargetType="{x:Type TextBlock}">
-                            <Setter Property="VerticalAlignment" Value="Center" />
-                        </Style>
-                    </DataGridTextColumn.ElementStyle>
-                </DataGridTextColumn>
-                <DataGridTemplateColumn Width="*" Header="{x:Static prop:Resources.HeaderCoordinate}">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <TextBox
-								BorderThickness="0"
-								IsReadOnly="True"
-                                FontSize="12"
-                                FontFamily="{DynamicResource DefaultFontFamily}"
-								Text="{Binding OutputCoordinate}"
-                                Style="{DynamicResource Esri_DataGridRowTextBox}"/>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTemplateColumn CanUserResize="False">
-                    <DataGridTemplateColumn.Header>
-                        <Button
-							Margin="0,0,0,0"
-							Command="{Binding DataContext.CopyAllCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
-							ToolTip="{x:Static prop:Resources.TooltipCopyAll}"
-							Style="{StaticResource ImageButtonStyle}">
-                            <Image
-								Width="18"
-								Height="18"
-								Source="/CoordinateConversionLibrary;component/Images/copyall.png" />
-                        </Button>
-                    </DataGridTemplateColumn.Header>
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
+        <StackPanel>
+           
+            <DataGrid
+			    x:Name="ocGrid"
+			    AutoGenerateColumns="False"
+			    CanUserAddRows="False"
+			    CanUserDeleteRows="False"
+			    CanUserReorderColumns="False"
+			    CanUserResizeRows="False"
+			    CanUserSortColumns="False"
+			    ItemsSource="{Binding OutputCoordinateList}"
+			    PreviewMouseLeftButtonDown="OnMouseLeftButtonDown"
+			    SelectionMode="Single"
+			    SizeChanged="ocGrid_SizeChanged"
+                FontSize="12"
+                FontFamily="{DynamicResource DefaultFontFamily}"
+			    Style="{DynamicResource Esri_DataGrid}" ColumnHeaderStyle="{DynamicResource DataGridColumnHeaderStyleCustom}" RowHeaderStyle="{DynamicResource DataGridRowHeaderStyleCustom}">
+                <DataGrid.Resources>
+                    <Style x:Key="DataGridRowHeaderStyleCustom" TargetType="{x:Type DataGridRowHeader}">
+                        <Setter Property="MinWidth" Value="20"/>
+                        <Setter Property="MinHeight" Value="20"/>
+                        <Setter Property="Cursor" Value="Hand"/>
+                        <Setter Property="Foreground" Value="{DynamicResource Esri_TextStyleDefaultBrush}"/>
+                        <Setter Property="Background" Value="{DynamicResource Esri_ControlBackgroundBrush}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource Esri_BorderBrush}"/>
+                        <Setter Property="BorderThickness" Value="1,1,1,1"/>
+                        <!--<Setter Property="Background">
+                            <Setter.Value>
+                                <ImageBrush/>
+                            </Setter.Value>
+                        </Setter>-->
+                        <Style.Triggers>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsRowSelected" Value="False"/>
+                                    <Condition Property="IsMouseOver" Value="True"/>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background" Value="{DynamicResource Esri_Blue2}"/>
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsRowSelected" Value="True"/>
+                                    <Condition Property="IsMouseOver" Value="False"/>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background" Value="{DynamicResource Esri_Blue6}"/>
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsRowSelected" Value="True"/>
+                                    <Condition Property="IsMouseOver" Value="True"/>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background" Value="{DynamicResource Esri_Blue3}"/>
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsRowSelected" Value="False"/>
+                                    <Condition Property="IsMouseOver" Value="False"/>
+                                    <Condition Property="Behaviors:DataGridBehavior.IsSelectedHeader" Value="True"/>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background" Value="{DynamicResource Esri_Blue6}"/>
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsRowSelected" Value="False"/>
+                                    <Condition Property="IsMouseOver" Value="True"/>
+                                    <Condition Property="Behaviors:DataGridBehavior.IsSelectedHeader" Value="True"/>
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background" Value="{DynamicResource Esri_Blue3}"/>
+                            </MultiTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.Resources>
+                <DataGrid.RowHeaderTemplate>
+                    <DataTemplate>
+                        <Image
+						    Width="10"
+						    Height="10"
+						    Cursor="Hand"
+						    Source="/CoordinateConversionLibrary;component/Images/RowHandle.png" />
+                    </DataTemplate>
+                </DataGrid.RowHeaderTemplate>
+                <DataGrid.RowStyle>
+                    <Style TargetType="{x:Type DataGridRow}">
+                        <Setter Property="DetailsVisibility" Value="{Binding DVisibility}" />
+                        <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
+                        <Style.Triggers>
+                            <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                                <Setter Property="Background" Value="{DynamicResource Esri_ControlBackgroundBrush}"></Setter>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.RowStyle>
+                <DataGrid.Columns>
+                    <DataGridTemplateColumn CanUserResize="False">
+                        <DataGridTemplateColumn.Header>
                             <Button
-								Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
-								CommandParameter="{Binding OutputCoordinate}"
-								ToolTip="{x:Static prop:Resources.TooltipCopy}"
-								Style="{StaticResource ImageButtonStyle}">
+							    Grid.Column="2"
+							    Margin="0,0,0,0"
+							    Command="{Binding DataContext.AddNewOCCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
+							    ToolTip="{x:Static prop:Resources.TooltipAdd}"
+							    Style="{StaticResource ImageButtonStyle}">
                                 <Image
-									Width="16"
-									Height="16"
-									Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
+								    Height="18"
+								    Width="18"
+								    Source="/CoordinateConversionLibrary;component/Images/hand.png" />
                             </Button>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-            </DataGrid.Columns>
-            <DataGrid.RowDetailsTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Vertical">
-                        <ListBox HorizontalContentAlignment="Stretch" ItemsSource="{Binding Props}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" MinWidth="55" />
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock
-                                            FontSize="12"
-                                            FontFamily="{DynamicResource DefaultFontFamily}"
-											Margin="3,3,0,0"
-											VerticalAlignment="Center"
-											Text="{Binding Key, Mode=OneWay}"/>
-                                        <TextBox
-                                            FontSize="12"
-                                            FontFamily="{DynamicResource DefaultFontFamily}"
-											Grid.Column="1"
-											Margin="3,3,0,0"
-											IsReadOnly="True"
-											Text="{Binding Value, Mode=OneWay}"/>
-                                        <Button
-											Grid.Column="2"
-											Margin="3,3,0,0"
-											Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
-											CommandParameter="{Binding Value}"
-											ToolTip="Copy"
-											Style="{StaticResource ImageButtonStyle}">
-                                            <Image
-												Width="16"
-												Height="16"
-												Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
-                                        </Button>
-                                    </Grid>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Command="{Binding DataContext.ExpandCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}" CommandParameter="{Binding Name}">
+                                    <Button.Style>
+                                        <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ImageButtonStyle}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Collapsed">
+                                                    <!--<Setter Property="Content" Value="?" />-->
+                                                    <Setter Property="Content" Value="{StaticResource expandImg}" />
+                                                    <Setter Property="ToolTip" Value="Expand" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding DetailsVisibility, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}" Value="Visible">
+                                                    <!--<Setter Property="Content" Value="?" />-->
+                                                    <Setter Property="Content" Value="{StaticResource collapseImg}" />
+                                                    <Setter Property="ToolTip" Value="Collapse" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTextColumn
+					    Width="Auto"
+					    MinWidth="40"
+					    Binding="{Binding Name}"
+                        FontSize="12"
+                        FontFamily="{DynamicResource DefaultFontFamily}"
+					    FontWeight="Bold"
+					    Header="{x:Static prop:Resources.HeaderName}"
+					    IsReadOnly="True"
+					    SortDirection="Ascending">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTemplateColumn Width="*" Header="{x:Static prop:Resources.HeaderCoordinate}">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBox
+								    BorderThickness="0"
+								    IsReadOnly="True"
+                                    FontSize="12"
+                                    FontFamily="{DynamicResource DefaultFontFamily}"
+								    Text="{Binding OutputCoordinate}"
+                                    Style="{DynamicResource Esri_DataGridRowTextBox}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn CanUserResize="False">
+                        <DataGridTemplateColumn.Header>
+                            <Button
+							    Margin="0,0,0,0"
+							    Command="{Binding DataContext.CopyAllCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
+							    ToolTip="{x:Static prop:Resources.TooltipCopyAll}"
+							    Style="{StaticResource ImageButtonStyle}">
+                                <Image
+								    Width="18"
+								    Height="18"
+								    Source="/CoordinateConversionLibrary;component/Images/copyall.png" />
+                            </Button>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button
+								    Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
+								    CommandParameter="{Binding OutputCoordinate}"
+								    ToolTip="{x:Static prop:Resources.TooltipCopy}"
+								    Style="{StaticResource ImageButtonStyle}">
+                                    <Image
+									    Width="16"
+									    Height="16"
+									    Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+                <DataGrid.RowDetailsTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical">
+                            <ListBox HorizontalContentAlignment="Stretch" ItemsSource="{Binding Props}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" MinWidth="55" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock
+                                                FontSize="12"
+                                                FontFamily="{DynamicResource DefaultFontFamily}"
+											    Margin="3,3,0,0"
+											    VerticalAlignment="Center"
+											    Text="{Binding Key, Mode=OneWay}"/>
+                                            <TextBox
+                                                FontSize="12"
+                                                FontFamily="{DynamicResource DefaultFontFamily}"
+											    Grid.Column="1"
+											    Margin="3,3,0,0"
+											    IsReadOnly="True"
+											    Text="{Binding Value, Mode=OneWay}"/>
+                                            <Button
+											    Grid.Column="2"
+											    Margin="3,3,0,0"
+											    Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"
+											    CommandParameter="{Binding Value}"
+											    ToolTip="Copy"
+											    Style="{StaticResource ImageButtonStyle}">
+                                                <Image
+												    Width="16"
+												    Height="16"
+												    Source="/CoordinateConversionLibrary;component/Images/EditCopy16.png" />
+                                            </Button>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </DataTemplate>
+                </DataGrid.RowDetailsTemplate>
+                <!--<DataGrid.ContextMenu>
+                    <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
+                        <MenuItem Header="Configure" Command="{Binding DataContext.ConfigCommand}" CommandParameter="{Binding }" />
+                        <MenuItem Header="Configure2" Command="{Binding DataContext.ConfigCommand}"
+                                  CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ContextMenu}, Path=PlacementTarget.CurrentItem.Name}" />
+                    </ContextMenu>
+                </DataGrid.ContextMenu>-->
+            </DataGrid>
+            <!--  Drag and Drop Popup  -->
+            <Popup
+			    x:Name="popup1"
+			    AllowsTransparency="True"
+			    IsHitTestVisible="False"
+			    Placement="RelativePoint"
+			    PlacementTarget="{Binding ElementName=ocView}">
+                <Border
+				    Background="{DynamicResource Esri_ControlBackgroundBrush}"
+                    Opacity="0.85"
+                    BorderBrush="{DynamicResource Esri_BorderBrush}"
+                    BorderThickness="2">
+                    <StackPanel Margin="4,3,8,3" Orientation="Horizontal">
+                        <Image
+						    Width="16"
+						    Height="16"
+						    Margin="5,0,0,0"
+						    Source="/CoordinateConversionLibrary;component/Images/hand.png" />
+                        <TextBlock
+						    Margin="8,0,0,0"
+						    VerticalAlignment="Center"
+						    FontWeight="Bold"
+                            FontSize="14"
+						    Text="{Binding DraggedItem.Name, ElementName=ocView}"  Style="{StaticResource Esri_TextBlockRegular}"/>
                     </StackPanel>
-                </DataTemplate>
-            </DataGrid.RowDetailsTemplate>
-            <!--<DataGrid.ContextMenu>
-                <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
-                    <MenuItem Header="Configure" Command="{Binding DataContext.ConfigCommand}" CommandParameter="{Binding }" />
-                    <MenuItem Header="Configure2" Command="{Binding DataContext.ConfigCommand}"
-                              CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ContextMenu}, Path=PlacementTarget.CurrentItem.Name}" />
-                </ContextMenu>
-            </DataGrid.ContextMenu>-->
-        </DataGrid>
-        <!--  Drag and Drop Popup  -->
-        <Popup
-			x:Name="popup1"
-			AllowsTransparency="True"
-			IsHitTestVisible="False"
-			Placement="RelativePoint"
-			PlacementTarget="{Binding ElementName=ocView}">
-            <Border
-				Background="{DynamicResource Esri_ControlBackgroundBrush}"
-                Opacity="0.85"
-                BorderBrush="{DynamicResource Esri_BorderBrush}"
-                BorderThickness="2">
-                <StackPanel Margin="4,3,8,3" Orientation="Horizontal">
-                    <Image
-						Width="16"
-						Height="16"
-						Margin="5,0,0,0"
-						Source="/CoordinateConversionLibrary;component/Images/hand.png" />
-                    <TextBlock
-						Margin="8,0,0,0"
-						VerticalAlignment="Center"
-						FontWeight="Bold"
-                        FontSize="14"
-						Text="{Binding DraggedItem.Name, ElementName=ocView}"  Style="{StaticResource Esri_TextBlockRegular}"/>
-                </StackPanel>
-            </Border>
-        </Popup>
+                </Border>
+            </Popup>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="btnReset" Content="Reset" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                Command="{Binding ResetButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
+                <Button x:Name="btnImport" Content="Import" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                Command="{Binding ImportButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
+                <Button x:Name="btnExport" Content="Export" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                Command="{Binding ExportButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
@@ -139,6 +139,7 @@
 			    CanUserReorderColumns="False"
 			    CanUserResizeRows="False"
 			    CanUserSortColumns="False"
+                MaxHeight="220"
 			    ItemsSource="{Binding OutputCoordinateList}"
 			    PreviewMouseLeftButtonDown="OnMouseLeftButtonDown"
 			    SelectionMode="Single"

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProSelectCoordinateFieldsView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProSelectCoordinateFieldsView.xaml
@@ -14,8 +14,9 @@
              WindowStartupLocation="CenterScreen"
              Title="{x:Static prop:Resources.TitleSelectCoordinateFields}"
              SizeToContent="WidthAndHeight"
+                     Topmost="True"
              helpers:DialogCloser.DialogResult="{Binding DialogResult}"
-                     d:DesignHeight="200" d:DesignWidth="420">
+                     d:DesignHeight="300" d:DesignWidth="420">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -64,6 +65,23 @@
                       SelectedItem="{Binding SelectedField2}"
                       ItemContainerStyle="{StaticResource comboBoxItemStyle}">
             </ComboBox>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,10,0,0">
+            <TextBlock Text="Additional Fields" Margin="0,5,5,5" VerticalAlignment="Center"/>
+            <ListBox SelectedItem="{Binding Path=SelectedFieldItem,UpdateSourceTrigger=PropertyChanged}" 
+                    ItemsSource="{Binding FieldCollection, NotifyOnSourceUpdated=True}" Width="253" Height="100" Margin="20,0,0,0" SelectionMode="Multiple" >
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="{x:Type ListBoxItem}">
+                        <Setter Property="IsSelected" Value="{Binding Mode=TwoWay, Path=IsSelected}"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+
+            </ListBox>
         </StackPanel>
         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" VerticalAlignment="Bottom">
             <Button Command="{Binding OKButtonPressedCommand}"


### PR DESCRIPTION
This pull request addresses the GitHub tickets mentioned below:
- #578 - Clear All, Import, and Export buttons should have a hover action
- #575 - DDM Formatter returning results in incorrect hemisphere 
- #573 - Buttons do not support dark theme
- #569 - Right-click to view values associated with points in the list
- #568 - When importing files to Coordinate Conversion, persist fields from input
- #567 - Support .xls and .xlsx as import types for Coordinate Conversion
- #565 - Paste coordinates into the List using keyboard shortcut Ctrl+V
- #564 - Copy coordinates from List using shortcut Ctrl+C
- #522 - Retrieve/copy different formats for coordinates already in the List
- #448 - Enhancement - enable save and load a set of 'favorites' coordinate output formats
