### PR TITLE
Delivery for Coordinate Conversion Addin DotNet 2.4.1 - Sprint 1 of 1

### DIFF
--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/ArcMapTabBaseViewModel.cs
@@ -930,7 +930,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
             using (ComReleaser oComReleaser = new ComReleaser())
             {
 
-                IFeatureWorkspace workspace = CreateFeatureWorkspace("tempWorkspace");
+                IFeatureWorkspace workspace = FeatureClassUtils.CreateFeatureWorkspace("tempWorkspace");
                 if (workspace == null)
                 {
                 }
@@ -1005,20 +1005,7 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
         {
             IWorkspaceFactory workspaceFactory = new AccessWorkspaceFactoryClass();
             return workspaceFactory.OpenFromFile(workspacePath, 0);
-        }
-
-        public static IFeatureWorkspace CreateFeatureWorkspace(string workspaceNameString)
-        {
-
-            IScratchWorkspaceFactory2 ipScWsFactory = new FileGDBScratchWorkspaceFactoryClass();
-            IWorkspace ipScWorkspace = ipScWsFactory.CurrentScratchWorkspace;
-            if (null == ipScWorkspace)
-                ipScWorkspace = ipScWsFactory.CreateNewScratchWorkspace();
-
-            IFeatureWorkspace featWork = (IFeatureWorkspace)ipScWorkspace;
-
-            return featWork;
-        }
+        }       
 
         /// <summary>
         /// Start Editing operation

--- a/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
+++ b/source/CoordinateConversion/ArcMapAddinCoordinateConversion/ViewModels/CollectTabViewModel.cs
@@ -237,18 +237,14 @@ namespace ArcMapAddinCoordinateConversion.ViewModels
                     {
                         string kmlName = System.IO.Path.GetFileName(path);
                         string folderName = System.IO.Path.GetDirectoryName(path);
-                        string tempShapeFile = folderName + System.IO.Path.DirectorySeparatorChar +
-                            "tmpShapefile.shp";
                         var grpList = GetMapPointExportFormat(GraphicsList);
-                        IFeatureClass tempFc = fcUtils.CreateFCOutput(tempShapeFile, SaveAsType.Shapefile, grpList, ArcMap.Document.FocusMap.SpatialReference);
+                        var fileNameWithoutExt = System.IO.Path.GetFileNameWithoutExtension(kmlName);
+                        IFeatureClass tempFc = fcUtils.CreateFCOutput(fileNameWithoutExt, SaveAsType.KML, grpList, ArcMap.Document.FocusMap.SpatialReference);
 
                         if (tempFc != null)
                         {
                             var kmlUtils = new KMLUtils();
-                            kmlUtils.ConvertLayerToKML(path, tempShapeFile, ArcMap.Document.FocusMap);
-
-                            // delete the temporary shapefile
-                            fcUtils.DeleteShapeFile(tempShapeFile);
+                            kmlUtils.ConvertLayerToKML(tempFc,path, fileNameWithoutExt, ArcMap.Document.FocusMap);
                         }
                     }
                 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/Constants.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Helpers/Constants.cs
@@ -47,6 +47,7 @@ namespace CoordinateConversionLibrary
         public const string MGRSCustomFormat = "ZSX00000Y00000";
         public const string USNGCustomFormat = "ZSX00000Y00000";
         public const string UTMCustomFormat = "Z#B X0 Y0";
-
+        public const double SymbolSize = 10;
+        public const string LayerToKMLGPTool = "LayerToKML_conversion";
     }
 }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.Designer.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.Designer.cs
@@ -691,6 +691,42 @@ namespace CoordinateConversionLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open.
+        /// </summary>
+        public static string Open {
+            get {
+                return ResourceManager.GetString("Open", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pop-up.
+        /// </summary>
+        public static string Popup {
+            get {
+                return ResourceManager.GetString("Popup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string Reset {
+            get {
+                return ResourceManager.GetString("Reset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        public static string Save {
+            get {
+                return ResourceManager.GetString("Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show N/S/E/W.
         /// </summary>
         public static string ShowNSEW {
@@ -912,15 +948,6 @@ namespace CoordinateConversionLibrary.Properties {
         public static string UseTwoFields {
             get {
                 return ResourceManager.GetString("UseTwoFields", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to View Details.
-        /// </summary>
-        public static string ViewDetails {
-            get {
-                return ResourceManager.GetString("ViewDetails", resourceCulture);
             }
         }
     }

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.resx
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Properties/Resources.resx
@@ -381,8 +381,8 @@
   <data name="MsgNoDataFound" xml:space="preserve">
     <value>No data found.</value>
   </data>
-  <data name="ViewDetails" xml:space="preserve">
-    <value>View Details</value>
+  <data name="Popup" xml:space="preserve">
+    <value>Pop-up</value>
   </data>
   <data name="InformationNotAvailableMsg" xml:space="preserve">
     <value>No Field information associated with this point</value>
@@ -404,5 +404,14 @@
   </data>
   <data name="ShowPlusHyphen" xml:space="preserve">
     <value>Show +/-</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
   </data>
 </root>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/OutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/ViewModels/OutputCoordinateViewModel.cs
@@ -209,7 +209,7 @@ namespace CoordinateConversionLibrary.ViewModels
             }
         }
 
-        private void OnDeleteCommand(object obj)
+        public virtual void OnDeleteCommand(object obj)
         {
             var name = obj as string;
 

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/CCCollectTabView.xaml
@@ -117,7 +117,7 @@
                         <MenuItem
                         Command="{Binding DataContext.ViewDetailCommand}"
                         CommandParameter="{Binding}"
-                        Header="{x:Static prop:Resources.ViewDetails}"
+                        Header="{x:Static prop:Resources.Popup}"
                         IsEnabled="{Binding DataContext.HasListBoxRightClickSelectedItem}"/>
                     </ContextMenu>
                 </ListBox.ContextMenu>

--- a/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
+++ b/source/CoordinateConversion/CoordinateConversionLibrary/Views/OutputCoordinateView.xaml
@@ -252,9 +252,12 @@
                 </Border>
             </Popup>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="btnReset" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Reset" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ResetButtonCommand}"/>
-                <Button x:Name="btnImport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Import" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ImportButtonCommand}"/>
-                <Button x:Name="btnExport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" Content="Export" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ExportButtonCommand}"/>
+                <Button x:Name="btnReset" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" 
+                        Content="{x:Static prop:Resources.Reset}" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ResetButtonCommand}"/>
+                <Button x:Name="btnImport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" 
+                        Content="{x:Static prop:Resources.Open}" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ImportButtonCommand}"/>
+                <Button x:Name="btnExport" Margin="3,3,0,0" Style="{StaticResource TransparentButtonStyle}" 
+                        Content="{x:Static prop:Resources.Save}" HorizontalAlignment="Left" VerticalAlignment="Top" Command="{Binding ExportButtonCommand}"/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Models/FeatureClassUtils.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Models/FeatureClassUtils.cs
@@ -203,7 +203,7 @@ namespace ProAppCoordConversionModule.Models
                     rowBuffer.Dispose();
             }
         }
-        private static async Task CreateFeatures(List<CCProGraphic> mapPointList, string layerName)
+        private static async Task CreateFeatures(List<CCProGraphic> mapPointList, string layerName, bool isKML)
         {
             ArcGIS.Core.Data.RowBuffer rowBuffer = null;
             try
@@ -258,10 +258,10 @@ namespace ProAppCoordConversionModule.Models
                             if (currentRenderer != null)
                             {
                                 CIMSymbolReference sybmol = currentRenderer.Symbol;
-
                                 //var outline = SymbolFactory.ConstructStroke(ColorFactory.RedRGB, 1.0, SimpleLineStyle.Solid);
-                                //var s = SymbolFactory.ConstructPolygonSymbol(ColorFactory.RedRGB, SimpleFillStyle.Null, outline);
+                                //var s = SymbolFactory.ConstructPolygonSymbol(ColorFactory.RedRGB, SimpleFillStyle.Null, outline);                                
                                 var s = SymbolFactory.Instance.ConstructPointSymbol(ColorFactory.Instance.RedRGB, 3.0);
+                                if (isKML) s.SetSize(CoordinateConversionLibrary.Constants.SymbolSize);
                                 CIMSymbolReference symbolRef = new CIMSymbolReference() { Symbol = s };
                                 currentRenderer.Symbol = symbolRef;
 
@@ -428,7 +428,7 @@ namespace ProAppCoordConversionModule.Models
                     }
                 }
 
-                await CreateFeatures(mapPointList, dataset);
+                await CreateFeatures(mapPointList, dataset, isKML);
 
                 if (isKML)
                 {

--- a/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/ViewModels/ProOutputCoordinateViewModel.cs
@@ -207,6 +207,30 @@ namespace ProAppCoordConversionModule.ViewModels
             CoordinateConversionLibraryConfig.AddInConfig.SaveConfiguration();
             RaisePropertyChanged(() => CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList);
         }
+
+        public override void OnDeleteCommand(object obj)
+        {
+            var name = obj as string;
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                if (
+                    System.Windows.MessageBoxResult.Yes !=
+                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(string.Format(CoordinateConversionLibrary.Properties.Resources.FormattedRemove, name),
+                    CoordinateConversionLibrary.Properties.Resources.LabelConfirmRemoval, System.Windows.MessageBoxButton.YesNo))
+                    return;
+
+                foreach (var item in CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList)
+                {
+                    if (item.Name == name)
+                    {
+                        CoordinateConversionLibraryConfig.AddInConfig.OutputCoordinateList.Remove(item);
+                        CoordinateConversionLibraryConfig.AddInConfig.SaveConfiguration();
+                        return;
+                    }
+                }
+            }
+        }
         #endregion
     }
 }

--- a/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
+++ b/source/CoordinateConversion/ProAppCoordConversionModule/Views/ProOutputCoordinateView.xaml
@@ -398,11 +398,11 @@
                 </Border>
             </Popup>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="btnReset" Content="Reset" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                <Button x:Name="btnReset" Content="{x:Static prop:Resources.Reset}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
                 Command="{Binding ResetButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
-                <Button x:Name="btnImport" Content="Import" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                <Button x:Name="btnImport" Content="{x:Static prop:Resources.Open}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
                 Command="{Binding ImportButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
-                <Button x:Name="btnExport" Content="Export" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
+                <Button x:Name="btnExport" Content="{x:Static prop:Resources.Save}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="3,3,0,0"
                 Command="{Binding ExportButtonCommand}" Style="{DynamicResource TransparentButtonStyle}"/>
             </StackPanel>
         </StackPanel>


### PR DESCRIPTION
Github issues resolved in this release:

- #627 - Buttons for importing and exporting an Output list should be renamed
- #614 - View Details should be renamed to "Pop-up"
- #595 - Export coordinates to KMZ output symbols are too small
- #587 - If there are points in the List that have fields different than other points in the List, only the fields from the top point are exported to FC/SHP/KML
- #562 - Confirm Removal? dialog box does not support Dark Theme